### PR TITLE
Fix error on entirely numeric camera_name

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1928,7 +1928,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@network_smb_ver', '1.0')
     data.setdefault('@network_username', '')
     data.setdefault('@network_password', '')
-    data.setdefault('target_dir', os.path.join(settings.MEDIA_PATH, data['camera_name']))
+    data.setdefault('target_dir', os.path.join(settings.MEDIA_PATH, str(data['camera_name'])))
     data.setdefault('@upload_enabled', False)
     data.setdefault('@upload_picture', True)
     data.setdefault('@upload_movie', True)


### PR DESCRIPTION
If you have a camera_name that is only numbers then you would get an
AttributeError if you add multiple cameras.

Example scenario below:

I'm running MotionEyeOS 20190427 on a Raspberry PI 3B.

After adding two simple network cameras to a MotionEyeOS server, if I name them "15" and "16" then the server crashes and I can see the following error message in the logs:
```
2019-07-07 22:53:37: [motioneye]    ERROR: 'int' object has no attribute 'startswith'
Traceback (most recent call last):
  File "usr/lib/python2.7/site-packages/tornado/web.py", line 1499, in _stack_context_handle_exception
  File "usr/lib/python2.7/site-packages/tornado/web.py", line 1700, in wrapper
  File "/usr/lib/python2.7/site-packages/motioneye/handlers.py", line 273, in get
  File "/usr/lib/python2.7/site-packages/motioneye/handlers.py", line 205, in wrapper
  File "/usr/lib/python2.7/site-packages/motioneye/handlers.py", line 610, in list
  File "/usr/lib/python2.7/site-packages/motioneye/config.py", line 318, in get_camera_ids
  File "/usr/lib/python2.7/site-packages/motioneye/config.py", line 406, in get_camera
  File "/usr/lib/python2.7/site-packages/motioneye/config.py", line 1872, in _set_default_motion_camera
  File "usr/lib/python2.7/posixpath.py", line 68, in join
AttributeError: 'int' object has no attribute 'startswith'
```
This has to do with parsing of the config files.
https://github.com/ccrisan/motioneye/blob/fc3387e9d13e4bd8c6066aa710955839578a3673/motioneye/config.py#L1869