### PR TITLE
Enable uploading of media files to minio(s3 compatible)

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
     curl -L --output /tmp/motion.deb https://github.com/Motion-Project/motion/releases/download/release-4.2.2/cosmic_motion_4.2.2-1_amd64.deb && \
     dpkg -i /tmp/motion.deb && \
     rm /tmp/motion.deb && \
+    pip install minio && \
     pip install /tmp/motioneye && \
     rm -rf /tmp/motioneye && \
     apt-get purge --yes \

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -391,7 +391,7 @@ def get_camera(camera_id, as_lines=False):
     camera_config = _conf_to_dict(lines,
                                   no_convert=['@network_share_name', '@network_smb_ver', '@network_server',
                                               '@network_username', '@network_password', '@storage_device',
-                                              '@upload_server', '@upload_username', '@upload_password'])
+                                              '@upload_server','@upload_access_key','@upload_secret_key','@upload_bucket', '@upload_username', '@upload_password'])
 
     if utils.is_local_motion_camera(camera_config):
         # determine the enabled status
@@ -715,6 +715,11 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         '@upload_picture': ui['upload_picture'],
         '@upload_service': ui['upload_service'],
         '@upload_server': ui['upload_server'],
+
+        '@upload_access_key': ui['upload_access_key'],
+        '@upload_secret_key': ui['upload_secret_key'],
+        '@upload_bucket': ui['upload_bucket'],
+
         '@upload_port': ui['upload_port'],
         '@upload_method': ui['upload_method'],
         '@upload_location': ui['upload_location'],
@@ -1081,6 +1086,9 @@ def motion_camera_dict_to_ui(data):
         'upload_movie': data['@upload_movie'],
         'upload_service': data['@upload_service'],
         'upload_server': data['@upload_server'],
+        'upload_access_key': data['@upload_access_key'],
+        'upload_secret_key': data['@upload_secret_key'],
+        'upload_bucket': data['@upload_bucket'],
         'upload_port': data['@upload_port'],
         'upload_method': data['@upload_method'],
         'upload_location': data['@upload_location'],
@@ -1872,6 +1880,12 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@upload_movie', True)
     data.setdefault('@upload_service', 'ftp')
     data.setdefault('@upload_server', '')
+
+    data.setdefault('@upload_access_key', '')
+    data.setdefault('@upload_secret_key', '')
+    data.setdefault('@upload_bucket', '')
+
+
     data.setdefault('@upload_port', '')
     data.setdefault('@upload_method', 'POST')
     data.setdefault('@upload_location', '')
@@ -1881,7 +1895,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@clean_cloud_enabled', False)
 
     data.setdefault('stream_localhost', False)
-    data.setdefault('stream_port', 8080 + camera_id)
+    data.setdefault('stream_port', 8080 + int(camera_id))
     data.setdefault('stream_maxrate', 5)
     data.setdefault('stream_quality', 85)
     data.setdefault('stream_motion', False)

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1893,6 +1893,9 @@ function cameraUi2Dict() {
         'upload_movie': $('#uploadMovieSwitch')[0].checked,
         'upload_service': $('#uploadServiceSelect').val(),
         'upload_server': $('#uploadServerEntry').val(),
+        'upload_access_key': $('#uploadAccessKeyEntry').val(),
+        'upload_secret_key': $('#uploadSecretKeyEntry').val(),
+        'upload_bucket': $('#uploadBucketEntry').val(),
         'upload_port': $('#uploadPortEntry').val(),
         'upload_method': $('#uploadMethodSelect').val(),
         'upload_location': $('#uploadLocationEntry').val(),
@@ -2215,6 +2218,9 @@ function dict2CameraUi(dict) {
     $('#uploadMovieSwitch')[0].checked = dict['upload_movie']; markHideIfNull('upload_movie', 'uploadMovieSwitch');
     $('#uploadServiceSelect').val(dict['upload_service']); markHideIfNull('upload_service', 'uploadServiceSelect');
     $('#uploadServerEntry').val(dict['upload_server']); markHideIfNull('upload_server', 'uploadServerEntry');
+    $('#uploadAccessKeyEntry').val(dict['upload_access_key']); markHideIfNull('upload_access_key', 'uploadAccessKeyEntry');
+    $('#uploadSecretKeyEntry').val(dict['upload_secret_key']); markHideIfNull('upload_secret_key', 'uploadSecretKeyEntry');
+    $('#uploadBucketEntry').val(dict['upload_bucket']); markHideIfNull('upload_bucket', 'uploadBucketEntry');
     $('#uploadPortEntry').val(dict['upload_port']); markHideIfNull('upload_port', 'uploadPortEntry');
     $('#uploadMethodSelect').val(dict['upload_method']); markHideIfNull('upload_method', 'uploadMethodSelect');
     $('#uploadLocationEntry').val(dict['upload_location']); markHideIfNull('upload_location', 'uploadLocationEntry');
@@ -2920,7 +2926,7 @@ function doRestore() {
 }
 
 function doTestUpload() {
-    var q = $('#uploadPortEntry, #uploadLocationEntry, #uploadServerEntry');
+    var q = $('#uploadPortEntry, #uploadLocationEntry, #uploadServerEntry, #uploadAccessKeyEntry, #uploadSecretKeyEntry, #uploadBucketEntry');
     var valid = true;
     q.each(function() {
         this.validate();
@@ -2941,6 +2947,9 @@ function doTestUpload() {
         server: $('#uploadServerEntry').val(),
         port: $('#uploadPortEntry').val(),
         method: $('#uploadMethodSelect').val(),
+        access_key: $('#uploadAccessKeyEntry').val(),
+        secret_key: $('#uploadSecretKeyEntry').val(),
+        bucket: $('#uploadBucketEntry').val(),
         location: $('#uploadLocationEntry').val(),
         subfolders: $('#uploadSubfoldersSwitch')[0].checked,
         username: $('#uploadUsernameEntry').val(),

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -419,16 +419,17 @@
                                     <option value="gdrive">Google Drive</option>
                                     <option value="gphoto">Google Photo</option>
                                     <option value="dropbox">Dropbox</option>
+                                    <option value="minio">Minio</option>
                                 </select>
                             </td>
                             <td><span class="help-mark" title="choose a service to which the media files should be uploaded">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
+                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https|minio)">
                             <td class="settings-item-label"><span class="settings-item-label">Server Address</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadServerEntry"></td>
                             <td><span class="help-mark" title="the domain name or IP address of the server (e.g. ftp.example.com or 192.168.1.3)">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
+                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https|minio)">
                             <td class="settings-item-label"><span class="settings-item-label">Server Port</span></td>
                             <td class="settings-item-value"><input type="text" class="number styled storage camera-config" id="uploadPortEntry"></td>
                             <td><span class="help-mark" title="the port to use when connecting to the service (leave it empty to use the default value)">?</span></td>
@@ -448,6 +449,25 @@
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadLocationEntry"></td>
                             <td><span class="help-mark" title="the location (root path) where media files should be uploaded (e.g. /files/cam1/)">?</span></td>
                         </tr>
+
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(minio)">
+                            <td class="settings-item-label"><span class="settings-item-label">ACCESS KEY</span></td>
+                            <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadAccessKeyEntry"></td>
+                            <td><span class="help-mark" title="Access key">?</span></td>
+                        </tr>
+
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(minio)">
+                            <td class="settings-item-label"><span class="settings-item-label">SECRET KEY</span></td>
+                            <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadSecretKeyEntry"></td>
+                            <td><span class="help-mark" title="Secret key">?</span></td>
+                        </tr>
+
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(minio)">
+                            <td class="settings-item-label"><span class="settings-item-label">Bucket</span></td>
+                            <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadBucketEntry"></td>
+                            <td><span class="help-mark" title="Minio bucket">?</span></td>
+                        </tr>
+
                         <tr class="settings-item" depends="uploadEnabled uploadService!=(gphoto)">
                             <td class="settings-item-label"><span class="settings-item-label">Include Subfolders</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="uploadSubfoldersSwitch"></td>

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
 
     packages=['motioneye'],
 
-    install_requires=['tornado>=3.1,<6', 'jinja2', 'pillow', 'pycurl'],
+    install_requires=['tornado>=3.1,<6', 'jinja2', 'pillow', 'pycurl', 'minio'],
 
     package_data={
         'motioneye': [

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
 
     packages=['motioneye'],
 
-    install_requires=['tornado>=3.1,<6', 'jinja2', 'pillow', 'pycurl', 'minio'],
+    install_requires=['tornado>=3.1,<6', 'jinja2', 'pillow', 'pycurl'],
 
     package_data={
         'motioneye': [


### PR DESCRIPTION
This is a PR to enable the upload of files to [minio](https://min.io/). Minio is s3 compatible and and be run locally using docker.

I have added the required settings on the settings in the UI and tested the functionality both locally and on a minio instance in the cloud.

This is related to [this issue](https://github.com/ccrisan/motioneye/issues/1485)

 