### PR TITLE
add file upload support for webdav

### DIFF
--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -454,16 +454,17 @@
                                     <option value="gphoto">Google Photo</option>
                                     <option value="dropbox">Dropbox</option>
                                     <option value="s3">S3 (AWS/MinIO/...)</option>
+                                    <option value="nextcloud">Nextcloud</option>
                                 </select>
                             </td>
                             <td><span class="help-mark" title="{{ _("elektu servon, al kiu la mediadosieroj estu alŝutitaj") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
+                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Servila Adreso") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadServerEntry"></td>
                             <td><span class="help-mark" title="{{ _("la domajna nomo aŭ IP-adreso de la servilo (ekz. ftp.example.com aŭ 192.168.1.3)") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
+                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Servila haveno") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="number styled storage camera-config" id="uploadPortEntry"></td>
                             <td><span class="help-mark" title="{{ _("la haveno por uzi konekti al la servo (lasu ĉi tiun kampon malplena por uzi la defaŭltan valoron)") }}">?</span></td>
@@ -493,12 +494,12 @@
                             <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="cleanCloudEnabledSwitch"></td>
                             <td><span class="help-mark" title="{{ _("ebligu ĉi tion forigi amaskomunikilaĵojn dosierojn alŝutitajn al la nubo ankaŭ kiam loka amaskomunikilaro estas forigita konforme al la agordo de persistemo de dosieroj. Nuntempe ĉi tiu opcio nur haveblas por gdrivo.") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Uzantnomo") }}</span></td>
                             <td class="settings-item-value"><input type="text" autocapitalize="none" class="styled storage camera-config" id="uploadUsernameEntry"></td>
                             <td><span class="help-mark" title="{{ _("la uzantnomo por la alŝuta servo-konto") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Pasvorto") }}</span></td>
                             <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadPasswordEntry"></td>
                             <td><span class="help-mark" title="{{ _("la pasvorto por la alŝuta servo-konto") }}">?</span></td>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -454,17 +454,17 @@
                                     <option value="gphoto">Google Photo</option>
                                     <option value="dropbox">Dropbox</option>
                                     <option value="s3">S3 (AWS/MinIO/...)</option>
-                                    <option value="nextcloud">Nextcloud</option>
+                                    <option value="webdav">WebDAV</option>
                                 </select>
                             </td>
                             <td><span class="help-mark" title="{{ _("elektu servon, al kiu la mediadosieroj estu alŝutitaj") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
+                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Servila Adreso") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadServerEntry"></td>
                             <td><span class="help-mark" title="{{ _("la domajna nomo aŭ IP-adreso de la servilo (ekz. ftp.example.com aŭ 192.168.1.3)") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
+                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Servila haveno") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="number styled storage camera-config" id="uploadPortEntry"></td>
                             <td><span class="help-mark" title="{{ _("la haveno por uzi konekti al la servo (lasu ĉi tiun kampon malplena por uzi la defaŭltan valoron)") }}">?</span></td>
@@ -494,12 +494,12 @@
                             <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="cleanCloudEnabledSwitch"></td>
                             <td><span class="help-mark" title="{{ _("ebligu ĉi tion forigi amaskomunikilaĵojn dosierojn alŝutitajn al la nubo ankaŭ kiam loka amaskomunikilaro estas forigita konforme al la agordo de persistemo de dosieroj. Nuntempe ĉi tiu opcio nur haveblas por gdrivo.") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Uzantnomo") }}</span></td>
                             <td class="settings-item-value"><input type="text" autocapitalize="none" class="styled storage camera-config" id="uploadUsernameEntry"></td>
                             <td><span class="help-mark" title="{{ _("la uzantnomo por la alŝuta servo-konto") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|nextcloud)">
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Pasvorto") }}</span></td>
                             <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadPasswordEntry"></td>
                             <td><span class="help-mark" title="{{ _("la pasvorto por la alŝuta servo-konto") }}">?</span></td>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -464,7 +464,7 @@
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadServerEntry"></td>
                             <td><span class="help-mark" title="{{ _("la domajna nomo aŭ IP-adreso de la servilo (ekz. ftp.example.com aŭ 192.168.1.3)") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
+                        <tr class="settings-item" required="true" min="1" max="65535" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Servila haveno") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="number styled storage camera-config" id="uploadPortEntry"></td>
                             <td><span class="help-mark" title="{{ _("la haveno por uzi konekti al la servo (lasu ĉi tiun kampon malplena por uzi la defaŭltan valoron)") }}">?</span></td>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -459,7 +459,7 @@
                             </td>
                             <td><span class="help-mark" title="{{ _("elektu servon, al kiu la mediadosieroj estu alŝutitaj") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
+                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Servila Adreso") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadServerEntry"></td>
                             <td><span class="help-mark" title="{{ _("la domajna nomo aŭ IP-adreso de la servilo (ekz. ftp.example.com aŭ 192.168.1.3)") }}">?</span></td>
@@ -478,6 +478,13 @@
                                 </select>
                             </td>
                             <td><span class="help-mark" title="{{ _("la HTTP-metodo uzi por alŝuti dosierojn") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(s3|webdav)">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Endpoint URL") }}</span></td>
+                            <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadEndpointUrlEntry"></td>
+                            <td><span class="help-mark" title="{{ _("The complete URL to the upload server endpoint:") }}
+      {{ _("For S3: E.g. http://my.minio:9000. Leave it empty for AWS!") }}
+      {{ _("For WebDAV: E.g. https://my.cloud/remote.php/dav/files/Me/") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" required="true" depends="uploadEnabled uploadService!=(s3)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Loko") }}</span></td>
@@ -517,11 +524,6 @@
                                 </div>
                             </td>
                             <td><span class="help-mark" title="{{ _("alklaku ĉi tie por akiri la ŝlosilan rajtigan servon") }}">?</span></td>
-                        </tr>
-                        <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
-                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Endpoint URL") }}</span></td>
-                            <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadEndpointUrlEntry"></td>
-                            <td><span class="help-mark" title="{{ _("The complete URL to the S3 server endpoint, e.g. http://my.minio:9000. Leave this empty for AWS!") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Access Key") }}</span></td>
@@ -1108,8 +1110,8 @@
                             <td><span class="help-mark" title="{{ _("difinas la bildan serĉtempan intervalon por krei telegramajn aldonojn (pli altaj valoroj generas pli da bildoj koste de pliigita sciiga prokrasto); agordi al 0 por malebligi bildajn aldonaĵojn; vi devas ankaŭ ebligi Senmovajn Bildojn por ke ĉi tio funkciu; vi volos ludi per ĉi tiu numero ĝis bildo estos sendita. Bona komenca numero estas 30 se vi agordas senmovajn bildojn al unu bildmoviĝo ekigita. Por norma movado ekigita, starigu ĉi tion multe pli malalte.") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" required="true" depends="telegramNotificationsEnabled motionDetectionEnabled" strip="true">
-				<td class="settings-item-label"><a href="https://core.telegram.org/bots#6-botfather" target="_blank"><div class="button normal-button test-button" id="apiInstructionButton" style="opacity: 1; display: inline-block;">{{ _("API-Informoj") }}</div></a></td>
-				<td class="settings-item-label"><div class="button normal-button test-button" id="telegramTestButton" style="opacity: 1; display: inline-block;">{{ _("Testo") }}</div></td>
+                            <td class="settings-item-label"><a href="https://core.telegram.org/bots#6-botfather" target="_blank"><div class="button normal-button test-button" id="apiInstructionButton" style="opacity: 1; display: inline-block;">{{ _("API-Informoj") }}</div></a></td>
+                            <td class="settings-item-label"><div class="button normal-button test-button" id="telegramTestButton" style="opacity: 1; display: inline-block;">{{ _("Testo") }}</div></td>
                         </tr>
                         <tr class="settings-item" depends="motionDetectionEnabled">
                             <td colspan="100"><div class="settings-item-separator"></div></td>
@@ -1301,7 +1303,6 @@
                     </table>
                     {% endif %}
                     {% endfor %}
-
                     <div class="settings-progress"></div>
                 </form>
             </div>
@@ -1314,9 +1315,8 @@
     </div>
     {% else %}
         <div class="camera-frame" id="camera{{camera_id}}"
-                streaming_framerate="{{camera_config['stream_maxrate']}}" streaming_server_resize="{{camera_config['@webcam_server_resize']|string|lower}}"
-                proto="{{camera_config['@proto']}}" url="{{camera_config['@url']}}">
-
+            streaming_framerate="{{camera_config['stream_maxrate']}}" streaming_server_resize="{{camera_config['@webcam_server_resize']|string|lower}}"
+            proto="{{camera_config['@proto']}}" url="{{camera_config['@url']}}">
             <div class="camera-container">
                 <div class="camera-placeholder"><img class="no-camera" src="{{static_path}}img/no-camera.svg"></div>
                 <img class="camera">

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from base64 import b64encode
 import datetime
 import ftplib
 import io
@@ -24,6 +23,7 @@ import mimetypes
 import os
 import os.path
 import time
+from base64 import b64encode
 from urllib.error import HTTPError
 from urllib.parse import quote, urlencode
 from urllib.request import Request
@@ -896,7 +896,7 @@ class Webdav(UploadService):
 
     def _request(self, url, method, body=None):
         base64string = b64encode(f'{self._username}:{self._password}')
-        headers = { 'Authorization' : 'Basic %s' % base64string }
+        headers = {'Authorization': 'Basic %s' % base64string}
         if body is not None:
             headers.update('Content-Length', '%d' % len(body))
         self.debug('request: ' + method + ' ' + url)
@@ -906,7 +906,9 @@ class Webdav(UploadService):
             utils.urlopen(request)
         except urllib.HTTPError as e:
             if method == 'MKCOL' and e.code == 405:
-                self.debug('MKCOL failed with code 405, this is normal if the folder exists')
+                self.debug(
+                    'MKCOL failed with code 405, this is normal if the folder exists'
+                )
             else:
                 raise e
 
@@ -930,7 +932,7 @@ class Webdav(UploadService):
         path = self._location.strip('/') + '/' + os.path.dirname(filename) + '/'
         filename = os.path.basename(filename)
         self._make_dirs(path)
-        self.debug('uploading %s of %s bytes' % (filename, len(data)))
+        self.debug(f'uploading {filename} of {len(data)} bytes')
         self._request(self._server + path + filename, 'PUT', bytearray(data))
         self.debug('upload done')
 
@@ -939,7 +941,7 @@ class Webdav(UploadService):
             'server': self._server,
             'username': self._username,
             'password': self._password,
-            'location': self._location
+            'location': self._location,
         }
 
     def load(self, data):

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -886,7 +886,7 @@ class Webdav(UploadService):
     NAME = 'webdav'
 
     def __init__(self, camera_id):
-        self._server = None
+        self._endpoint_url = None
         self._username = None
         self._password = None
         self._location = None
@@ -914,7 +914,7 @@ class Webdav(UploadService):
                 raise e
 
     def _make_dirs(self, path):
-        dir_url = self._server.rstrip('/') + '/'
+        dir_url = self._endpoint_url.rstrip('/') + '/'
         for folder in path.split('/'):
             dir_url = dir_url + folder + '/'
             self._request(dir_url, 'MKCOL')
@@ -923,7 +923,7 @@ class Webdav(UploadService):
         try:
             path = self._location.strip('/') + '/' + str(time.time())
             self._make_dirs(path)
-            self._request(self._server.rstrip('/') + '/' + path, 'DELETE')
+            self._request(self._endpoint_url.rstrip('/') + '/' + path, 'DELETE')
             return True
         except Exception as e:
             self.error(str(e), exc_info=True)
@@ -935,7 +935,7 @@ class Webdav(UploadService):
         self._make_dirs(path)
         self.debug(f'uploading {filename} of {len(data)} bytes')
         self._request(
-            self._server.rstrip('/') + '/' + path + '/' + filename,
+            self._endpoint_url.rstrip('/') + '/' + path + '/' + filename,
             'PUT',
             bytearray(data),
         )
@@ -943,15 +943,15 @@ class Webdav(UploadService):
 
     def dump(self):
         return {
-            'server': self._server,
+            'endpoint_url': self._endpoint_url,
             'username': self._username,
             'password': self._password,
             'location': self._location,
         }
 
     def load(self, data):
-        if data.get('server') is not None:
-            self._server = data['server']
+        if data.get('endpoint_url') is not None:
+            self._endpoint_url = data['endpoint_url']
         if data.get('username') is not None:
             self._username = data['username']
         if data.get('password') is not None:

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -895,16 +895,18 @@ class Webdav(UploadService):
         UploadService.__init__(self, camera_id)
 
     def _request(self, url, method, body=None):
-        base64string = b64encode(f'{self._username}:{self._password}')
-        headers = {'Authorization': 'Basic %s' % base64string}
+        base64string = b64encode(f'{self._username}:{self._password}'.encode()).decode(
+            'ascii'
+        )
+        headers = {'Authorization': f'Basic {base64string}'}
         if body is not None:
-            headers.update('Content-Length', '%d' % len(body))
-        self.debug('request: ' + method + ' ' + url)
+            headers.update({'Content-Length': len(body)})
+        self.debug(f'request: {method} {url}')
         request = urllib.request.Request(url, data=body, headers=headers)
         request.get_method = lambda: method
         try:
             utils.urlopen(request)
-        except urllib.HTTPError as e:
+        except urllib.error.HTTPError as e:
             if method == 'MKCOL' and e.code == 405:
                 self.debug(
                     'MKCOL failed with code 405, this is normal if the folder exists'


### PR DESCRIPTION
Hello, 
this is an UploadService implementation for nextcloud. 
- It uses the same settings as the FTP UploadService
- urllib2 for requests
- creates folders recursively

The requests for uploading files as well as the ones used for creating and deleting directories are documented [here](https://docs.nextcloud.com/server/18/developer_manual/client_apis/WebDAV/basic.html#uploading-files).
Also I can provide nextcloud accounts for testing, just pm me.

I hope you like it :)