### PR TITLE
Alter meta viewport to allow pinch to zoom.

### DIFF
--- a/motioneye/templates/base.html
+++ b/motioneye/templates/base.html
@@ -4,7 +4,7 @@
         {% block meta %}
             <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
             <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="mobile-web-app-capable" content="yes">
             <meta name="apple-mobile-web-app-capable" content="yes">
             <meta name="theme-color" content="#414141">


### PR DESCRIPTION
Currently the ability to pinch to zoom is disabled on the web app. I often find myself trying to do it though, as on a mobile screen it is hard to make out details. This small tweak enables the feature without breaking the normal experience in any way.