### PR TITLE
Add build_arg to set motion version for Docker (and other small fixes)

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -59,15 +59,14 @@ COPY extra/motioneye.conf.sample /usr/share/motioneye/extra/
 COPY extra/docker-entrypoint.sh /docker-entrypoint.sh
 
 # R/W needed for motioneye to update configurations
+RUN mkdir /etc/motioneye && chown motion:motion /etc/motioneye
 VOLUME /etc/motioneye
 
 # Video & images
+RUN mkdir /var/lib/motioneye && chown motion:motion /var/lib/motioneye
 VOLUME /var/lib/motioneye
 
-CMD test -e /etc/motioneye/motioneye.conf || \
-    cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
-    # We need to chown at startup time since volumes are mounted as root. This is fugly.
-    chown motion:motion /var/run /var/log /etc/motioneye /var/lib/motioneye /usr/share/motioneye/extra ; \
-    su -g motion motion -s /bin/bash -c "/usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf"
-
-EXPOSE 8765
+RUN chmod a+rwx /var/run /var/log
+USER motion
+EXPOSE 8765 8081
+CMD ["/docker-entrypoint.sh"]

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
       libpq5 \
       lsb-release \
       mosquitto-clients \
+      procps \
       python-jinja2 \
       python-pil \
       python-pip \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
+ARG MOTION_RELEASE=4.3.2
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.label-schema.build-date=$BUILD_DATE \
@@ -16,11 +17,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 ARG RUN_UID=0
 ARG RUN_GID=0
 
-COPY . /tmp/motioneye
-
-RUN echo "deb http://snapshot.debian.org/archive/debian/$(date +%Y%m%d) sid main contrib non-free" >>/etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -t stable --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get --yes --no-install-recommends install \
       curl \
       ffmpeg \
       libmicrohttpd12 \
@@ -36,16 +34,17 @@ RUN echo "deb http://snapshot.debian.org/archive/debian/$(date +%Y%m%d) sid main
       python-tornado \
       python-tz \
       python-wheel \
-      v4l-utils && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -t sid --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-      motion \
-      libmysqlclient20 && \
-    # Change uid/gid of user/group motion to match our desired IDs.  This will
-    # make it easier to use execute motion as our desired user later.
-    sed -i -e "s/^\(motion:[^:]*\):[0-9]*:[0-9]*:\(.*\)/\1:${RUN_UID}:${RUN_GID}:\2/" /etc/passwd && \
-    sed -i -e "s/^\(motion:[^:]*\):[0-9]*:\(.*\)/\1:${RUN_GID}:\2/" /etc/group && \
-    pip install /tmp/motioneye && \
-    # Cleanup
+      tini \
+      v4l-utils
+
+RUN export TARGET=$(dpkg --print-architecture); \
+    curl -LO https://github.com/Motion-Project/motion/releases/download/release-${MOTION_RELEASE}/buster_motion_${MOTION_RELEASE}-1_${TARGET}.deb && \
+    apt-get -y install ./buster_motion_${MOTION_RELEASE}-1_${TARGET}.deb && \
+    rm -f ./buster_motion_${MOTION_RELEASE}-1_${TARGET}.deb
+
+COPY . /tmp/motioneye
+
+RUN pip install /tmp/motioneye && \
     rm -rf /tmp/motioneye && \
     apt-get purge --yes python-setuptools python-wheel && \
     apt-get autoremove --yes && \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -13,9 +13,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/ccrisan/motioneye.git"
 
-# By default, run as root.
-ARG RUN_UID=0
-ARG RUN_GID=0
+# default motion user is 101:101
+ARG RUN_UID=101
+ARG RUN_GID=101
 
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --yes --no-install-recommends install \
@@ -50,7 +50,13 @@ RUN pip install /tmp/motioneye && \
     apt-get autoremove --yes && \
     apt-get --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
-ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
+# Change uid/gid of user/group motion to match our desired IDs.  This will
+# make it easier to use execute motion as our desired user later.
+RUN sed -i -e "s/^\(motion:[^:]*\):[0-9]*:[0-9]*:\(.*\)/\1:${RUN_UID}:${RUN_GID}:\2/" /etc/passwd && \
+    sed -i -e "s/^\(motion:[^:]*\):[0-9]*:\(.*\)/\1:${RUN_GID}:\2/" /etc/group
+
+COPY extra/motioneye.conf.sample /usr/share/motioneye/extra/
+COPY extra/docker-entrypoint.sh /docker-entrypoint.sh
 
 # R/W needed for motioneye to update configurations
 VOLUME /etc/motioneye

--- a/extra/README.md
+++ b/extra/README.md
@@ -19,6 +19,8 @@ docker run \
   ccrisan/motioneye:master-amd64
 ```
 
+Alternatively, the provided `docker-compose.yml` manifest can be used instead.
+
 This configuration maps motionEye configs into the `/data/motioneye/config`
 directory on the host. Videos will be saved under `/data/motioneye/videos`.
 Change the directories to suit your particular needs and make sure those
@@ -47,9 +49,9 @@ Use `docker volume ls` to view existing volumes.
 ## Building your own image
 
 It's also possible to build your own motionEye docker image. This allows the
-use of UIDs other than root for the `motion` and `meyectl` daemons (the default
-on official images). If you want to use a non-privileged user/group for
-motionEye, *please make sure that user/group exist on the host* before running
+use of UIDs other than the default (101:101) for the `motion` and `meyectl` daemons.
+If you want to use a non-privileged user/group for motionEye, 
+*please make sure that user/group exist on the host* before running
 the commands below.
 
 For the examples below, we assume user `motion` and group `motion` exist on the host server.
@@ -66,6 +68,8 @@ cd motioneye && \
 docker build \
   --build-arg="RUN_UID=${RUN_UID?}" \
   --build-arg="RUN_GID=${RUN_GID?}" \
+  --build-arg="VCS_REF=$(git rev-parse HEAD)" \
+  --build-arg="BUILD_DATE=${TIMESTAMP}" \
   -t "${USER?}/motioneye:${TIMESTAMP}" \
   --no-cache \
   -f extra/Dockerfile .

--- a/extra/docker-compose.yml
+++ b/extra/docker-compose.yml
@@ -2,6 +2,13 @@
 version: "3.5"
 services:
   motioneye:
+    container_name: motioneye
+    hostname: motioneye
+    build:
+      context: ..
+      dockerfile: extra/Dockerfile
+      args:
+        MOTION_RELEASE: "4.3.2"
     image: ccrisan/motioneye:master-amd64  # Change to ccrisan/motioneye:master-armhf for ARM chips (Pi etc.)
     ports:
       - "8081:8081"

--- a/extra/docker-compose.yml
+++ b/extra/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - etc_motioneye:/etc/motioneye
       - var_lib_motioneye:/var/lib/motioneye
+      - /etc/localtime:/etc/localtime:ro
 
 volumes:
   etc_motioneye:

--- a/extra/docker-entrypoint.sh
+++ b/extra/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+test -e /etc/motioneye/motioneye.conf || \
+	cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
+
+exec /usr/bin/tini /usr/local/bin/meyectl -- startserver -c /etc/motioneye/motioneye.conf


### PR DESCRIPTION
Hi,

Firstly thanks for this excellent project. I've replaced my existing VMS software with a first-class open source alternative.

This PR allows for the motion version to be defined in a Docker build arg. I'm successfully running it now with the latest version at the time of writing (4.3.2).

There are some other small fixes included here to address issues with volume permissions. It is now no longer necessary to run `chown` on container startup.

Finally, I've included `tini` as a small init process to prevent the container from hanging on shutdown.