### PR TITLE
Split only two times the VCGenCMD output

### DIFF
--- a/motioneye/mmalctl.py
+++ b/motioneye/mmalctl.py
@@ -39,7 +39,7 @@ def list_devices():
     except subprocess.CalledProcessError:  # not found
         return []
 
-    d = dict(p.split('=', 1) for p in support.split())
+    d = dict(p.split('=', 1) for p in support.split(' ', 2))
     if d.get('detected') == d.get('supported') == '1':
         logging.debug('MMAL camera detected')
         return [('vc.ril.camera', 'VideoCore Camera')]

--- a/motioneye/mmalctl.py
+++ b/motioneye/mmalctl.py
@@ -39,12 +39,7 @@ def list_devices():
     except subprocess.CalledProcessError:  # not found
         return []
 
-    # Temporary patch for camera detection on MMAL going wrong due to split failing
-    # The response from vcgencmd is "supported=1 detected=1, libcamera interfaces=0"
-    # split fails on the "libcamera interfaces" part originally. The comma was overlooked too.
-    # see https://github.com/ccrisan/motioneye/pull/2305#issuecomment-1058584622
-    d = dict(p.split('=', 1) for p in support.split(' ', 2))
-    if d.get('detected').strip(',') == d.get('supported').strip(',') == '1':
+    if support.startswith('supported=1 detected=1'):
         logging.debug('MMAL camera detected')
         return [('vc.ril.camera', 'VideoCore Camera')]
 

--- a/motioneye/mmalctl.py
+++ b/motioneye/mmalctl.py
@@ -42,6 +42,7 @@ def list_devices():
     # Temporary patch for camera detection on MMAL going wrong due to split failing
     # The response from vcgencmd is "supported=1 detected=1, libcamera interfaces=0"
     # split fails on the "libcamera interfaces" part originally. The comma was overlooked too.
+    # see https://github.com/ccrisan/motioneye/pull/2305#issuecomment-1058584622
     d = dict(p.split('=', 1) for p in support.split(' ', 2))
     if d.get('detected').strip(',') == d.get('supported').strip(',') == '1':
         logging.debug('MMAL camera detected')

--- a/motioneye/mmalctl.py
+++ b/motioneye/mmalctl.py
@@ -39,8 +39,11 @@ def list_devices():
     except subprocess.CalledProcessError:  # not found
         return []
 
+    # Temporary patch for camera detection on MMAL going wrong due to split failing
+    # The response from vcgencmd is "supported=1 detected=1, libcamera interfaces=0"
+    # split fails on the "libcamera interfaces" part originally. The comma was overlooked too.
     d = dict(p.split('=', 1) for p in support.split(' ', 2))
-    if d.get('detected') == d.get('supported') == '1':
+    if d.get('detected').strip(',') == d.get('supported').strip(',') == '1':
         logging.debug('MMAL camera detected')
         return [('vc.ril.camera', 'VideoCore Camera')]
 


### PR DESCRIPTION
Python breaks on the third split (`libcamera interfaces=0`). As it splits on the empty part, it becomes `[libcamera, interfaces=0]`, which it can't split any further on an equal sign.