### PR TITLE
GitHub Action to test our Ubuntu wiki page

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,0 +1,27 @@
+# https://github.com/motioneye-project/motioneye/wiki/%28Install-On-Ubuntu-%2820.04-or-Newer%29
+name: ubuntu_build
+on: [pull_request, push]
+jobs:
+  ubuntu_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt-get -q update
+      - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade
+      - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install
+             curl ffmpeg libcurl4-openssl-dev libffi-dev libjpeg-dev libssl-dev
+             libzbar-dev libzbar0 motion python3-dev python3-pip ssh v4l-utils
+      # - run: python3 -m pip install https://github.com/motioneye-project/motioneye/archive/dev.zip
+      - run: sudo python3 -m pip install .  # Must be sudo.  See #1371
+      - run: sudo mkdir -p /etc/motioneye
+      - run: sudo cp motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
+      - run: sudo chown --recursive motion:motion /etc/motioneye
+      - run: sudo mkdir -p /var/lib/motioneye
+      - run: sudo chown --recursive motion:motion /var/lib/motioneye
+      - run: sudo cp motioneye/extra/motioneye.systemd-unit-local /etc/systemd/system/motioneye.service
+      - run: sudo systemctl daemon-reload
+      - run: sudo systemctl enable --now motioneye
+      # Docker on GitHub Actions is not exporting port 8765 but that is OK for this test.
+      - run: i=0; until ss -tln | grep 8765; do [ $i -le 10 ] || exit 0; sleep 1; i=$(expr $i + 1); done
+      - run: sudo systemctl status motioneye
+      - run: sudo systemctl is-active motioneye

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -15,9 +15,8 @@ jobs:
       - run: sudo python3 -m pip install .  # Must be sudo.  See #1371
       - run: sudo mkdir -p /etc/motioneye
       - run: sudo cp motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
-      - run: sudo chown --recursive motion:motion /etc/motioneye
       - run: sudo mkdir -p /var/lib/motioneye
-      - run: sudo chown --recursive motion:motion /var/lib/motioneye
+      - run: sudo chown --recursive motion /{etc,var/lib}/motioneye
       - run: sudo cp motioneye/extra/motioneye.systemd-unit-local /etc/systemd/system/motioneye.service
       - run: sudo systemctl daemon-reload
       - run: sudo systemctl enable --now motioneye


### PR DESCRIPTION
Build using https://github.com/motioneye-project/motioneye/wiki/%28Install-On-Ubuntu-%2820.04-or-Newer%29 as our guide.

@starbasessd Can you please help me with this effort?

I am trying to run as many steps as possible from the above wiki page and then test if we have a successful build.

$ `sudo systemctl status motioneye`
```
● motioneye.service - motionEye Server
     Loaded: loaded (/etc/systemd/system/motioneye.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2022-03-10 21:37:42 UTC; 87ms ago
   Main PID: 5965 (meyectl)
      Tasks: 1 (limit: 8327)
     Memory: 11.4M
     CGroup: /system.slice/motioneye.service
             └─5965 /usr/bin/python3 /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf

Mar 10 21:37:42 fv-az399-922 systemd[1]: Started motionEye Server.
```