### PR TITLE
Do not run jobs on pull_request event on base repo

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,6 +2,7 @@ name: make
 on: [pull_request, push]
 jobs:
   make:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,11 +1,10 @@
 # https://pre-commit.com
 # This GitHub Action assumes that the repo contains a valid .pre-commit-config.yaml file.
 name: pre-commit
-on:
-  pull_request:
-  push:
+on: [pull_request, push]
 jobs:
   pre-commit:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -2,6 +2,7 @@ name: test_python
 on: [pull_request, push]
 jobs:
   test_python:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -3,6 +3,7 @@ name: ubuntu_build
 on: [pull_request, push]
 jobs:
   ubuntu_build:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently, all jobs run doubled, onces because of the push event and one because of the pull_request event.

We want all jobs to run on push events, so that every commit is checked saparately, and we need the pull_request event to see jobs running on our own repo for pull requests from  forks.

To achieve this, we run jobs on pull_request events only if the owner of the action (us) matches the owner of the (HEAD) repository.

Futhermore, in case we add further jobs to workflows, this condition as well as the runner's OS is set as default for all jobs.