### PR TITLE
Read camera_name as string properly

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -401,7 +401,8 @@ def get_camera(camera_id, as_lines=False):
     camera_config = _conf_to_dict(lines,
                                   no_convert=['@network_share_name', '@network_smb_ver', '@network_server',
                                               '@network_username', '@network_password', '@storage_device',
-                                              '@upload_server', '@upload_username', '@upload_password'])
+                                              '@upload_server', '@upload_username', '@upload_password',
+                                              'camera_name'])
 
     if utils.is_local_motion_camera(camera_config):
         # determine the enabled status
@@ -1923,7 +1924,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@network_smb_ver', '1.0')
     data.setdefault('@network_username', '')
     data.setdefault('@network_password', '')
-    data.setdefault('target_dir', os.path.join(settings.MEDIA_PATH, str(data['camera_name'])))
+    data.setdefault('target_dir', os.path.join(settings.MEDIA_PATH, data['camera_name']))
     data.setdefault('@upload_enabled', False)
     data.setdefault('@upload_picture', True)
     data.setdefault('@upload_movie', True)


### PR DESCRIPTION
As of: #1361

When testing, I accidentally added `camera_name` to the wrong `no_convert` array in `main_config`, instead of the one in `camera_config`, which was the reason it did not work. Adding it to the correct `no_convert` array does indeed work and then seems to be the cleaner solution.