### PR TITLE
remove buffering policy argument from open() function call

### DIFF
--- a/motioneye/server.py
+++ b/motioneye/server.py
@@ -85,7 +85,7 @@ class Daemon(object):
         sys.stderr.flush()
         si = open('/dev/null', 'r')
         so = open('/dev/null', 'a+')
-        se = open('/dev/null', 'a+', 0)
+        se = open('/dev/null', 'a+')
         os.dup2(si.fileno(), sys.stdin.fileno())
         os.dup2(so.fileno(), sys.stdout.fileno())
         os.dup2(se.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
Part of an effort to port motioneye to Python 3