### PR TITLE
Add LICENSE to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
 	Programming Language :: Python :: 3
 	License :: OSI Approved :: GNU General Public License v3 (GPLv3)
 	Operating System :: POSIX :: Linux
+license = GNU General Public License v3.0
+license_files = LICENSE
 long_description = file: ReadMe.md
 long_description_content_type = text/markdown
 


### PR DESCRIPTION
Closes #2257  @rustypig91
**GNU General Public License v3.0** as discussed in https://setuptools.pypa.io/en/latest/userguide/declarative_config.html