### PR TITLE
Pre-commit: Enable check-executables-have-shebangs

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,7 +2,7 @@ name: make
 on: [pull_request, push]
 jobs:
   make:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ name: pre-commit
 on: [pull_request, push]
 jobs:
   pre-commit:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -2,7 +2,7 @@ name: test_python
 on: [pull_request, push]
 jobs:
   test_python:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -3,7 +3,7 @@ name: ubuntu_build
 on: [pull_request, push]
 jobs:
   ubuntu_build:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.action.repository, github.repository.owner) }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v4.1.0
     hooks:
       - id: check-builtin-literals
-      # - id: check-executables-have-shebangs
+      - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: check-yaml
       - id: detect-private-key

--- a/motioneye/scripts/po2json
+++ b/motioneye/scripts/po2json
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 FICIN=$1
 FICOUT=$2


### PR DESCRIPTION
Closes #2342

Pre-commit: Enable [`check-executables-have-shebangs`](https://github.com/pre-commit/pre-commit-hooks#check-executables-have-shebangs) and add a shebang line to ` motioneye/scripts/po2json`