### PR TITLE
Update and align install commands

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -13,11 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get -q update
-      - run: sudo apt-get -qq upgrade
-      - run: sudo apt-get -qq install gettext python3 python3-pip python3-babel python3-boto3 python3-jinja2
-                                      python3-numpy python3-pillow python3-pycurl python3-tornado
+      - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends dist-upgrade
+      - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends install
+                  ca-certificates curl gcc gettext libcurl4-openssl-dev libssl-dev python3-dev
+      - run: curl -sSfO 'https://bootstrap.pypa.io/get-pip.py'
+      - run: sudo python3 get-pip.py
+      - run: sudo python3 -m pip install --upgrade pip setuptools wheel
+      - run: python3 -m pip install --upgrade babel build
       - run: cd motioneye && make
-      - run: python3 -m pip install build && python3 -m build  # Stores .tar.gz and .whl files into ./dist
+      - run: python3 -m build  # Stores .tar.gz and .whl files into ./dist
       - run: sudo python3 -m pip install .
       - run: sudo motioneye_init --skip-apt-update
       - run: i=0; until ss -tln | grep 8765; do [ $i -le 10 ] || exit 0; sleep 1; i=$(expr $i + 1); done

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -14,12 +14,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - run: sudo apt-get -q update
-      - run: sudo apt-get -qq upgrade
-      - run: sudo apt-get -qq install curl ffmpeg libcurl4-openssl-dev libssl-dev motion ssh v4l-utils
-      - run: pip install --upgrade pip wheel
-      - run: pip install build mypy pytest safety
+      - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends dist-upgrade
+      - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends install
+             curl gcc ffmpeg libcurl4-openssl-dev libssl-dev motion v4l-utils
+      - run: sudo python3 -m pip install --upgrade pip setuptools wheel
+      - run: python3 -m pip install --upgrade build mypy pytest safety
       - run: python3 -m build
-      - run: pip install .
+      - run: python3 -m pip install .
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest --ignore=tests/test_utils/test_mjpeg.py

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -13,9 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get -q update
-      - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade
-      - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install
-             libcurl4-openssl-dev libssl-dev python3-dev python3-pip
+      - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends dist-upgrade
+      - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install
+                  ca-certificates curl gcc libcurl4-openssl-dev libssl-dev python3-dev
+      - run: curl -sSfO 'https://bootstrap.pypa.io/get-pip.py'
+      - run: sudo python3 get-pip.py
+      - run: sudo python3 -m pip install --upgrade pip setuptools wheel
       - run: |
           REPO=$GITHUB_REPOSITORY BRANCH=$GITHUB_REF_NAME
           [ ${{ github.event_name }} = 'pull_request' ] && REPO=${{ github.event.pull_request.head.repo.full_name }} BRANCH=${{ github.event.pull_request.head.ref }}

--- a/README.md
+++ b/README.md
@@ -24,21 +24,49 @@ The following languages have been translated by machine translation and must be 
 * Russian ( _русский язык_ )
 * Chinese ( _中文_ )
 
-# Installation :
+# Installation
 
-You need :
-* a linux machine (tested only on debian bullseye).
-* python3 and python3-pip.
-* recommended : python3-tornado ,python3-jinja2 ,python3-pillow ,python3-pycurl ,python3-babel ,python3-numpy ,python3-boto3
+These install instructions are constantly tested via CI/CD pipeline on Debian Bullseye and Ubuntu Focal.
 
-```
-sudo pip install motioneye
-sudo motioneye_init
-```
+1. Install **Python 3.7 or later** and build dependencies
+
+    _Here the commands for APT-based Linux distributions are given._
+
+    On **ARMv6 and ARMv7** systems:
+    ```sh
+    sudo apt update
+    sudo apt --no-install-recommends install ca-certificates curl python3 python3-distutils
+    ```
+
+    On all other architectures additional development headers are required:
+    ```sh
+    sudo apt update
+    sudo apt --no-install-recommends install ca-certificates curl python3 python3-dev libcurl4-openssl-dev gcc libssl-dev
+    ```
+
+2. Install the Python package manager `pip`
+    ```sh
+    curl -sSfO 'https://bootstrap.pypa.io/get-pip.py'
+    sudo python3 get-pip.py
+    rm get-pip.py
+    ```
+
+    On **ARMv6 and ARMv7** systems, additionally configure `pip` to use pre-compiled wheels from [piwheels](https://piwheels.org/):
+    ```sh
+    printf '%b' '[global]\nextra-index-url=https://www.piwheels.org/simple/\n' | sudo tee /etc/pip.conf > /dev/null
+    ```
+
+3. Install and setup **motionEye**
+    ```sh
+    sudo python3 -m pip install 'https://github.com/motioneye-project/motioneye/archive/dev.tar.gz'
+    sudo motioneye_init
+    ```
+    _NB: `motioneye_init` currently assumes either an APT- or RPM-based distribution with `systemd` as init system. For a manual setup, config and service files can be found here: <https://github.com/motioneye-project/motioneye/tree/dev/motioneye/extra> _
 
 # Upgrade
-```
+
+```sh
 sudo systemctl stop motioneye
-sudo pip install motioneye --upgrade
+sudo python3 -m pip install --upgrade --force-reinstall --no-deps 'https://github.com/motioneye-project/motioneye/archive/dev.tar.gz'
 sudo systemctl start motioneye
 ```

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -8,25 +8,29 @@ ARG RUN_GID=0
 COPY . /tmp/motioneye
 
 RUN case "$(dpkg --print-architecture)" in \
-      'armhf') PACKAGES=''; printf '%b' '[global]\nextra-index-url=https://www.piwheels.org/simple/\n' > /etc/pip.conf;; \
-      *) PACKAGES='python3-dev libcurl4-openssl-dev gcc libssl-dev';; \
+      'armhf') PACKAGES='python3-distutils'; printf '%b' '[global]\nextra-index-url=https://www.piwheels.org/simple/\n' > /etc/pip.conf;; \
+      *) PACKAGES='gcc libcurl4-openssl-dev libssl-dev python3-dev';; \
     esac && \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -y --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-      python3 python3-pip $PACKAGES tzdata && \
+    apt-get -q update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -qq --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+      ca-certificates curl python3 $PACKAGES && \
+    curl -sSfO 'https://bootstrap.pypa.io/get-pip.py' && \
+    python3 get-pip.py && \
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     # Change uid/gid of user/group motion to match our desired IDs. This will
     # make it easier to use execute motion as our desired user later.
     sed -i "s/^\(motion:[^:]*\):[0-9]*:[0-9]*:\(.*\)/\1:${RUN_UID}:${RUN_GID}:\2/" /etc/passwd && \
     sed -i "s/^\(motion:[^:]*\):[0-9]*:\(.*\)/\1:${RUN_GID}:\2/" /etc/group && \
-    pip3 install --no-cache-dir /tmp/motioneye && \
+    python3 -m pip install --no-cache-dir /tmp/motioneye && \
     motioneye_init --skip-systemd --skip-apt-update && \
     mv /etc/motioneye/motioneye.conf /etc/motioneye.conf.sample && \
     mkdir /var/log/motioneye /var/lib/motioneye && \
     chown motion:motion /var/log/motioneye /var/lib/motioneye && \
     # Cleanup
-    DEBIAN_FRONTEND="noninteractive" apt-get -y autopurge python3-pip $PACKAGES && \
+    python3 -m pip uninstall -y pip setuptools wheel && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -qq autopurge $PACKAGES && \
     apt-get clean && \
-    rm -r /var/lib/apt/lists /var/cache/apt /tmp/motioneye
+    rm -r /var/lib/apt/lists /var/cache/apt /tmp/motioneye get-pip.py /root/.cache
 
 # R/W needed for motionEye to update configurations
 VOLUME /etc/motioneye

--- a/motioneye/extra/linux_init
+++ b/motioneye/extra/linux_init
@@ -33,11 +33,11 @@ if command -v apt-get > /dev/null; then
     PI=''
     [[ $(uname -m) == 'armv6l' && -f '/sys/firmware/devicetree/base/model' ]] && grep -q 'aspberry' /sys/firmware/devicetree/base/model && PI='pi_'
     FILE="${PI}${DISTRO}_motion_${MOTION_REL}${MOTION_SUBREL}_${ARCH}.deb"
-    command -v curl > /dev/null || apt-get -y install curl
+    command -v curl > /dev/null || DEBIAN_FRONTEND="noninteractive" apt-get -y --no-install-recommends install curl
     curl -fLO "https://github.com/Motion-Project/motion/releases/download/release-${MOTION_REL}/${FILE}"
     MOTION="./${FILE}"
   fi
-  apt-get -y --no-install-recommends install "${MOTION}" curl v4l-utils ffmpeg curl
+  DEBIAN_FRONTEND="noninteractive" apt-get -y --no-install-recommends install "${MOTION}" v4l-utils ffmpeg curl
   [[ ${FILE} ]] && rm "${FILE}"
 elif command -v yum > /dev/null; then
   yum -y install motion v4l-utils ffmpeg curl


### PR DESCRIPTION
In workflows, all APT packages and Python modules are upgraded to latest versions.

In workflows, APT calls consequently use` DEBIAN_FRONTEND="noninteractive"`, `-qq` and `--no-install-recommends` flags to assure debconf cannot hang the call, to mute unnecessary processing output and to not install APT recommends. APT recommends are not installed by default on some Linux distributions, hence we want to test whether installs succeed without them, else add individual missing dependencies explicitly.

Python pip is now consequently installed via `get-pip.py`. There are two officially supported install methods, `ensurepip` and `get-pip.py`. Since `ensurepip` is usually not available when installing Python 3 via package manager, `get-pip.py` is the only officially supported method with assures latest `pip`, `setuptools` and `wheel` modules and works in every environment. The benefit is that it does not depend on the distribution and that way there are not conflicts between distribution package manager module versions and those installed with pip.
For reference: https://pip.pypa.io/en/stable/installation/

`python3 -m pip install` is used as generic pip install invocation, unless in workflows where we know exactly that `pip3 install` or `pip install` works, and where we do not want to explicitly test the generic install instructions.

Since all required Python modules are pulled in by motionEye as dependency, it is not required anymore to install any of them via distribution package manager. All commands and instructions have been aligned, following this logic:
- Python 3 is installed via distribution package manager, as well as `curl` for downloading `get-pip.py`.
- On all but ARMv6 and ARMv7 systems, Python 3/libcurl/libssl development headers as well as a C compiler are required to build the `pycurl` module, used by motionEye for SFTP uploads.
- `pip` is installed via `get-pip.py`, as universal working method to install latest `pip`, `setuptools` and `wheel` modules.
- On ARMv6 and ARMv7 systems, piwheels is added as additional pip index which provides pre-compiled wheels for those architectures, usually missing on PyPI, including `pycurl`.
- The motionEye module install pulls all Python dependencies.
- The `motioneye_init` command pull all non-Python dependencies and sets up motionEye with default config and systemd service.