### PR TITLE
Fix S3 and add generic S3 compatible server support

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -460,6 +460,10 @@ def get_camera(camera_id, as_lines=False):
             '@upload_server',
             '@upload_username',
             '@upload_password',
+            '@upload_endpoint_url',
+            '@upload_access_key',
+            '@upload_secret_key',
+            '@upload_bucket',
             'camera_name',
         ],
     )
@@ -819,6 +823,10 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         '@upload_subfolders': ui['upload_subfolders'],
         '@upload_username': ui['upload_username'],
         '@upload_password': ui['upload_password'],
+        '@upload_endpoint_url': ui['upload_endpoint_url'],
+        '@upload_access_key': ui['upload_access_key'],
+        '@upload_secret_key': ui['upload_secret_key'],
+        '@upload_bucket': ui['upload_bucket'],
         '@clean_cloud_enabled': ui['clean_cloud_enabled'],
         # text overlay
         'text_left': '',
@@ -1300,6 +1308,10 @@ def motion_camera_dict_to_ui(data):
         'upload_username': data['@upload_username'],
         'upload_password': data['@upload_password'],
         'upload_authorization_key': '',  # needed, otherwise the field is hidden
+        'upload_endpoint_url': data['@upload_endpoint_url'],
+        'upload_access_key': data['@upload_access_key'],
+        'upload_secret_key': data['@upload_secret_key'],
+        'upload_bucket': data['@upload_bucket'],
         'clean_cloud_enabled': data['@clean_cloud_enabled'],
         'web_hook_storage_enabled': False,
         'command_storage_enabled': False,
@@ -2176,6 +2188,10 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@upload_subfolders', True)
     data.setdefault('@upload_username', '')
     data.setdefault('@upload_password', '')
+    data.setdefault('@upload_endpoint_url', '')
+    data.setdefault('@upload_access_key', '')
+    data.setdefault('@upload_secret_key', '')
+    data.setdefault('@upload_bucket', '')
     data.setdefault('@clean_cloud_enabled', False)
 
     data.setdefault('stream_localhost', False)

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1932,9 +1932,10 @@ function cameraUi2Dict() {
         'upload_username': $('#uploadUsernameEntry').val(),
         'upload_password': $('#uploadPasswordEntry').val(),
         'upload_authorization_key': $('#uploadAuthorizationKeyEntry').val(),
-        'upload_secret_access_key': $('#uploadSecretAccessKeyEntry').val(),
+        'upload_endpoint_url': $('#uploadEndpointUrlEntry').val(),
+        'upload_access_key': $('#uploadAccessKeyEntry').val(),
+        'upload_secret_key': $('#uploadSecretKeyEntry').val(),
         'upload_bucket': $('#uploadBucketEntry').val(),
-	'upload_bucket_region': $('#uploadBucketRegionEntry').val(),
         'clean_cloud_enabled': $('#cleanCloudEnabledSwitch')[0].checked,
         'web_hook_storage_enabled': $('#webHookStorageEnabledSwitch')[0].checked,
         'web_hook_storage_url': $('#webHookStorageUrlEntry').val(),
@@ -2267,8 +2268,10 @@ function dict2CameraUi(dict) {
     $('#uploadUsernameEntry').val(dict['upload_username']); markHideIfNull('upload_username', 'uploadUsernameEntry');
     $('#uploadPasswordEntry').val(dict['upload_password']); markHideIfNull('upload_password', 'uploadPasswordEntry');
     $('#uploadAuthorizationKeyEntry').val(dict['upload_authorization_key']); markHideIfNull('upload_authorization_key', 'uploadAuthorizationKeyEntry');
-    $('#uploadSecretAccessKeyEntry').val(dict['upload_secret_access_key']);
-    $('#uploadBucketEntry').val(dict['upload_bucket']);
+    $('#uploadEndpointUrlEntry').val(dict['upload_endpoint_url']); markHideIfNull('upload_endpoint_url', 'uploadEndpointUrlEntry');
+    $('#uploadAccessKeyEntry').val(dict['upload_access_key']); markHideIfNull('upload_access_key', 'uploadAccessKeyEntry');
+    $('#uploadSecretKeyEntry').val(dict['upload_secret_key']); markHideIfNull('upload_secret_key', 'uploadSecretKeyEntry');
+    $('#uploadBucketEntry').val(dict['upload_bucket']); markHideIfNull('upload_bucket', 'uploadBucketEntry');
     $('#cleanCloudEnabledSwitch')[0].checked = dict['clean_cloud_enabled']; markHideIfNull('clean_cloud_enabled', 'cleanCloudEnabledSwitch');
 
     $('#webHookStorageEnabledSwitch')[0].checked = dict['web_hook_storage_enabled']; markHideIfNull('web_hook_storage_enabled', 'webHookStorageEnabledSwitch');
@@ -3008,8 +3011,10 @@ function doTestUpload() {
         username: $('#uploadUsernameEntry').val(),
         password: $('#uploadPasswordEntry').val(),
         authorization_key: $('#uploadAuthorizationKeyEntry').val(),
-        secret_access_key: $('#uploadSecretAccessKeyEntry').val,
-        bucket: $('#uploadBucketEntry').val
+        endpoint_url: $('#uploadEndpointUrlEntry').val(),
+        access_key: $('#uploadAccessKeyEntry').val(),
+        secret_key: $('#uploadSecretKeyEntry').val(),
+        bucket: $('#uploadBucketEntry').val()
     };
 
     var cameraId = $('#cameraSelect').val();

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -453,7 +453,7 @@
                                     <option value="gdrive">Google Drive</option>
                                     <option value="gphoto">Google Photo</option>
                                     <option value="dropbox">Dropbox</option>
-                                    <option value="s3">AWS S3</option>
+                                    <option value="s3">S3 (AWS/MinIO/...)</option>
                                 </select>
                             </td>
                             <td><span class="help-mark" title="{{ _("elektu servon, al kiu la mediadosieroj estu alŝutitaj") }}">?</span></td>
@@ -478,7 +478,7 @@
                             </td>
                             <td><span class="help-mark" title="{{ _("la HTTP-metodo uzi por alŝuti dosierojn") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" required="true" depends="uploadEnabled">
+                        <tr class="settings-item" required="true" depends="uploadEnabled uploadService!=(s3)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Loko") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadLocationEntry"></td>
                             <td><span class="help-mark" title="{{ _("la loko (radika vojo) kie amaskomunikiloj devas esti alŝutitaj (ekz. /files/cam1/)") }}">?</span></td>
@@ -503,7 +503,7 @@
                             <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadPasswordEntry"></td>
                             <td><span class="help-mark" title="{{ _("la pasvorto por la alŝuta servo-konto") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" depends="uploadEnabled uploadService=(gdrive|gphoto|dropbox|s3)">
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(gdrive|gphoto|dropbox)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Rajtiga ŝlosilo") }}</span></td>
                             <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadAuthorizationKeyEntry"></td>
                             <td><span class="help-mark" title="{{ _("la ŝlosilo uzata por aŭtentiĝi kun la alŝuta servo (kutime bezonata nur dum agordo)") }}">?</span></td>
@@ -518,8 +518,18 @@
                             <td><span class="help-mark" title="{{ _("alklaku ĉi tie por akiri la ŝlosilan rajtigan servon") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Endpoint URL") }}</span></td>
+                            <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadEndpointUrlEntry"></td>
+                            <td><span class="help-mark" title="{{ _("The complete URL to the S3 server endpoint, e.g. http://my.minio:9000. Leave this empty for AWS!") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Access Key") }}</span></td>
+                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadAccessKeyEntry"></td>
+                            <td><span class="help-mark" title="{{ _("The AWS access key used to authenticate with the upload service") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Sekreta Alira Ŝlosilo") }}</span></td>
-                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadSecretAccessKeyEntry"></td>
+                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadSecretKeyEntry"></td>
                             <td><span class="help-mark" title="{{ _("la AWS-sekreta alira ŝlosilo uzata por aŭtentiĝi kun la alŝuta servo (kutime bezonata nur dum agordo)") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">


### PR DESCRIPTION
WIP: AFAIK this still cannot work.

@jmichault 
You merged #1063 and finished the class, but it seems you didn't test it?
- False syntax in `main.js` prevented secret key and bucket inputs from being used, leading to a failure in `boto3`.
- I aligned show/hide method with how `upload_authorization_key` is handled, initialising it as empty string and then using `markHideIfNull` to hide it if `null`. I'm not sure about the rational behind this, but makes sense to follow existing logics.
- It still does not work. If I'm not mistaken, the authorization key is a one time access key for Google and Dropbox uploads, to authorize the client against the server, not required anymore after done, hence not saved to camera config. For S3 access however it is required on every upload, i.e. needs to be stored in the config, at least bucket and one of the other keys?
- Also there is this `'upload_bucket_region': $('#uploadBucketRegionEntry').val(),` in the code, which from what I see is never used, but instead you re-used the existing `location` input, which seems reasonable. Generally I'd suggest to re-use username and password configs for the two keys and just show them with different text, so we have no redundant/empty settings stored in camera configs while only one upload service can be selected anyway.

What I'm most unhappy with is that this does not work with other S3 compatible servers, just with AWS. There is another PR for adding MinIO support, but again MinIO only: #1490
_This PR may btw help to actually fix the AWS S3 implementation, e.g. see how the configs are handled and persistently stored in camera config._

I wonder whether there is a generic S3 module which works with AWS and MinIO and other S3 compatible servers. From a drop-down we could add a provider selection which translates to a URL (for AWS at least), combined with a "Custom" entry which, when selected, shows an additional custom URL input field.
**EDIT: Ah, `boto3` seems to be able to upload to other S3 compatible servers via `endpoint_url`: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client**

Also, I suggest to not make `boto3` (or whatever it will be) a hard dependency. Instead, when AWS S3 (or any other S3 server) is selected, and the related module is not found, a notification could be shown about how to install the missing module.