### PR TITLE
Add timer to motion restart until ports are completely freed

### DIFF
--- a/motioneye/motionctl.py
+++ b/motioneye/motionctl.py
@@ -200,7 +200,7 @@ def stop(invalidate=False):
                     return
 
                 except OSError as e:
-                    logging.debug(f'motion port has not been released yet: {e}')
+                    logging.debug(f'motion port has not yet been released: {e!r}')
                     waited_for += 1
                     time.sleep(1)
 


### PR DESCRIPTION
Extracted from original PR #2190 by @kpoman.

I'm not sure whether it's worth it, never faced any issues when applying settings which implies a motion restart. But if any of you faced a related issue (motion failed to start up again as port is not yet free), then we can merge it. I mainly did this to be able to close #2190 since all other changes it contains have been added/addressed to `dev` already.