### PR TITLE
Fix for page load causes 403 request (#2363)

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -528,8 +528,23 @@ function showErrorMessage(message) {
 }
 
 function doLogout() {
-    setCookie(USERNAME_COOKIE, '_');
+    setCookie(USERNAME_COOKIE, '');
+    setCookie(PASSWORD_COOKIE, '');
     window.location.reload(true);
+}
+
+function isAuthCookiesSet() {
+    var username = getCookie(USERNAME_COOKIE);
+    if(username == null || username == '') {
+        return false;
+    }
+
+    var password = getCookie(PASSWORD_COOKIE);
+    if(password == null || password == '') {
+        return false;
+    }
+
+    return true;
 }
 
 function authorizeUpload() {
@@ -5426,6 +5441,13 @@ function checkCameraErrors() {
     setTimeout(checkCameraErrors, 1000);
 }
 
+function doAuth() {
+    ajax('GET', basePath + "login/", null, function() {
+        if (!frame) {
+            fetchCurrentConfig(endProgress);
+        }
+    });
+}
 
     /* startup function */
 
@@ -5459,11 +5481,14 @@ $(document).ready(function () {
     initUI();
     beginProgress();
 
-    ajax('GET', basePath + 'login/', null, function () {
-        if (!frame) {
-            fetchCurrentConfig(endProgress);
-        }
-    });
+    if(isAuthCookiesSet()) {
+        doAuth();
+    } else {
+        runLoginDialog(function () {
+            window._loginRetry = true;
+            doAuth();
+        });
+    }
 
     refreshCameraFrames();
     checkCameraErrors();


### PR DESCRIPTION
Fix #2363 

Now logout will erase password cookie too. Previously it stayed active for 10 years. Because of this you could set proper username for username cookie and system let you in. 

I removed default _ value for username in a cookie. Hopefully this won't break something what I didn't see.

We are still using sha1 hashes for password. These are broken and should be fixed.
We are storing sha1 password hash in  a cookie(for 10 years).  Should we use tokens instead?