### PR TITLE
Fixes for video stream authentications

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -856,8 +856,8 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         ),
         'stream_authentication': main_config['@normal_username']
         + ':'
-        + main_config['@normal_password']
-        + main_config['@lang'],
+        + main_config['@normal_password'],
+        '@lang': main_config['@lang'],
         # still images
         'picture_output': False,
         'snapshot_interval': 0,

--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -40,8 +40,8 @@ class MjpgClient(IOStream):
     def __init__(self, camera_id, port, username, password, auth_mode):
         self._camera_id = camera_id
         self._port = port
-        self._username = (username or '').encode('utf8')
-        self._password = (password or '').encode('utf8')
+        self._username = username or ''
+        self._password = password or ''
         self._auth_mode = auth_mode
         self._auth_digest_state = {}
 
@@ -183,8 +183,7 @@ class MjpgClient(IOStream):
             logging.debug('mjpg client using basic authentication')
             auth_header = utils.build_basic_header(self._username, self._password)
             self.write(
-                b'GET / HTTP/1.0\r\nAuthorization: %s\r\nConnection: close\r\n\r\n'
-                % auth_header
+                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
             )
 
         elif (
@@ -242,14 +241,14 @@ class MjpgClient(IOStream):
 
             auth_header = utils.build_basic_header(self._username, self._password)
             w_data = (
-                b'GET / HTTP/1.0\r\nAuthorization: %s\r\nConnection: close\r\n\r\n'
-                % auth_header
+                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
             )
             w_future = utils.cast_future(self.write(w_data))
             w_future.add_done_callback(self._seek_http)
 
             return
 
+        data = data.decode()
         if data.startswith('Digest'):
             logging.debug('mjpg client using digest authentication')
 
@@ -263,15 +262,14 @@ class MjpgClient(IOStream):
                 'GET', '/', self._username, self._password, self._auth_digest_state
             )
             w_data = (
-                b'GET / HTTP/1.0\r\nAuthorization: %s\r\nConnection: close\r\n\r\n'
-                % auth_header
+                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
             )
             w_future = utils.cast_future(self.write(w_data))
             w_future.add_done_callback(self._seek_http)
 
             return
 
-        logging.error('mjpg client unknown authentication header: "%s"' % data)
+        logging.error(f'mjpg client unknown authentication header: {data}')
         self._seek_content_length()
 
     def _seek_content_length(self):

--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -198,8 +198,10 @@ class MjpgClient(IOStream):
 
         self._seek_http()
 
-    def _seek_http(self) -> None:
-        if self._check_error():
+    def _seek_http(self, future: Future = False) -> None:
+        result, _ = self._get_future_result(future) if future else (True, False)
+
+        if not result or self._check_error():
             return
 
         future = utils.cast_future(self.read_until_regex(br'HTTP/1.\d \d+ '))

--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -240,9 +240,7 @@ class MjpgClient(IOStream):
             logging.debug('mjpg client using basic authentication')
 
             auth_header = utils.build_basic_header(self._username, self._password)
-            w_data = (
-                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
-            )
+            w_data = f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
             w_future = utils.cast_future(self.write(w_data))
             w_future.add_done_callback(self._seek_http)
 
@@ -261,9 +259,7 @@ class MjpgClient(IOStream):
             auth_header = utils.build_digest_header(
                 'GET', '/', self._username, self._password, self._auth_digest_state
             )
-            w_data = (
-                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
-            )
+            w_data = f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
             w_future = utils.cast_future(self.write(w_data))
             w_future.add_done_callback(self._seek_http)
 

--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -54,7 +54,7 @@ class MjpgClient(IOStream):
 
         self.set_close_callback(self.on_close)
 
-    def do_connect(self) -> "Future[MjpgClient]":
+    def do_connect(self) -> 'Future[MjpgClient]':
         f = self.connect(('localhost', self._port))
         f.add_done_callback(self._on_connect)
         return f
@@ -64,16 +64,12 @@ class MjpgClient(IOStream):
 
     def on_close(self):
         logging.debug(
-            'connection closed for mjpg client for camera {camera_id} on port {port}'.format(
-                port=self._port, camera_id=self._camera_id
-            )
+            f'connection closed for mjpg client for camera {self._camera_id} on port {self._port}'
         )
 
         if MjpgClient.clients.pop(self._camera_id, None):
             logging.debug(
-                'mjpg client for camera {camera_id} on port {port} removed'.format(
-                    port=self._port, camera_id=self._camera_id
-                )
+                f'mjpg client for camera {self._camera_id} on port {self._port} removed'
             )
 
         if getattr(self, 'error', None) and self.error.errno != errno.ECONNREFUSED:
@@ -82,9 +78,7 @@ class MjpgClient(IOStream):
                 now - MjpgClient._last_erroneous_close_time
                 < settings.MJPG_CLIENT_TIMEOUT
             ):
-                msg = 'connection problem detected for mjpg client for camera {camera_id} on port {port}'.format(
-                    port=self._port, camera_id=self._camera_id
-                )
+                msg = f'connection problem detected for mjpg client for camera {self._camera_id} on port {self._port}'
 
                 logging.error(msg)
 
@@ -123,9 +117,7 @@ class MjpgClient(IOStream):
     def _check_error(self) -> bool:
         if self.socket is None:
             logging.warning(
-                'mjpg client connection for camera {camera_id} on port {port} is closed'.format(
-                    port=self._port, camera_id=self._camera_id
-                )
+                f'mjpg client connection for camera {self._camera_id} on port {self._port} is closed'
             )
 
             self.close()
@@ -144,9 +136,7 @@ class MjpgClient(IOStream):
 
     def _error(self, error) -> None:
         logging.error(
-            'mjpg client for camera {camera_id} on port {port} error: {msg}'.format(
-                port=self._port, camera_id=self._camera_id, msg=str(error)
-            ),
+            f'mjpg client for camera {self._camera_id} on port {self._port} error: {str(error)}',
             exc_info=True,
         )
 
@@ -174,9 +164,7 @@ class MjpgClient(IOStream):
             return
 
         logging.debug(
-            'mjpg client for camera {camera_id} connected on port {port}'.format(
-                port=self._port, camera_id=self._camera_id
-            )
+            f'mjpg client for camera {self._camera_id} connected on port {self._port}'
         )
 
         if self._auth_mode == 'basic':
@@ -292,11 +280,7 @@ class MjpgClient(IOStream):
 
         matches = re.findall(rb'(\d+)', data)
         if not matches:
-            self._error(
-                'could not find content length in mjpg header line "{header}"'.format(
-                    header=data
-                )
-            )
+            self._error(f'could not find content length in mjpg header line "{data}"')
 
             return
 
@@ -337,9 +321,7 @@ def get_jpg(camera_id):
             camera_config
         ):
             logging.error(
-                'could not start mjpg client for camera id {camera_id}: not enabled or not local'.format(
-                    camera_id=camera_id
-                )
+                f'could not start mjpg client for camera id {camera_id}: not enabled or not local'
             )
 
             return None
@@ -390,7 +372,7 @@ def _garbage_collector():
 
     now = time.time()
     for camera_id, client in list(MjpgClient.clients.items()):
-        logging.debug(f"_garbage_collector checking camera. id: {camera_id}")
+        logging.debug(f'_garbage_collector checking camera. id: {camera_id}')
         port = client.get_port()
 
         if client.closed():
@@ -401,9 +383,7 @@ def _garbage_collector():
         delta = now - last_jpg_time
         if delta > settings.MJPG_CLIENT_TIMEOUT:
             logging.error(
-                'mjpg client timed out receiving data for camera {camera_id} on port {port}'.format(
-                    camera_id=camera_id, port=port
-                )
+                f'mjpg client timed out receiving data for camera {camera_id} on port {port}'
             )
 
             if settings.MOTION_RESTART_ON_ERRORS:

--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -279,7 +279,7 @@ def parse_cookies(cookies_headers):
 
 
 def build_basic_header(username, password):
-    return 'Basic ' + base64.encodebytes(f'{username}:{password}').replace('\n', '')
+    return 'Basic %s' % base64.b64encode(f'{username}:{password}'.encode()).decode()
 
 
 def parse_basic_header(header):

--- a/motioneye/utils/mjpeg.py
+++ b/motioneye/utils/mjpeg.py
@@ -61,7 +61,7 @@ def test_mjpeg_url(
             validate_cert=settings.VALIDATE_CERTS,
         )
 
-        fetch_future = cast_future(AsyncHTTPClient(force_instance=True).fetch(request))
+        fetch_future = cast_future(AsyncHTTPClient(force_instance=True).fetch(request, raise_error=False))
         fetch_future.add_done_callback(on_response)
         return fetch_future
 
@@ -114,7 +114,9 @@ def test_mjpeg_url(
                 if m.group(1) == '1':
                     http_11[0] = True
 
-    def on_response(response: HTTPResponse):
+    def on_response(res_future: Future):
+        response = res_future.result()
+
         if not called[0]:
             if response.code == 401 and auth_modes and url_obj.username:
                 status_2xx[0] = False

--- a/motioneye/utils/mjpeg.py
+++ b/motioneye/utils/mjpeg.py
@@ -61,7 +61,9 @@ def test_mjpeg_url(
             validate_cert=settings.VALIDATE_CERTS,
         )
 
-        fetch_future = cast_future(AsyncHTTPClient(force_instance=True).fetch(request, raise_error=False))
+        fetch_future = cast_future(
+            AsyncHTTPClient(force_instance=True).fetch(request, raise_error=False)
+        )
         fetch_future.add_done_callback(on_response)
         return fetch_future
 


### PR DESCRIPTION
- Some changes to username and password encoding stuff
- Fix for invalid response parameter -> Future

Digest and Basic auth needs to be tested.

Existing problem(I check this when I have more time)
mjpgclient.py: Future add_done_callback includes future parameter into method call which isn't implemented properly.

https://github.com/motioneye-project/motioneye/blob/11c0f06abd7093fa6e4734e7801e158fb6680c6e/motioneye/mjpgclient.py#L249
https://github.com/motioneye-project/motioneye/blob/11c0f06abd7093fa6e4734e7801e158fb6680c6e/motioneye/mjpgclient.py#L270

method _seek_http doesn't accept future parameter
https://github.com/motioneye-project/motioneye/blob/11c0f06abd7093fa6e4734e7801e158fb6680c6e/motioneye/mjpgclient.py#L202