### PR TITLE
Create pypi_daily_build.yml

### DIFF
--- a/.github/workflows/pypi_daily_build.yml
+++ b/.github/workflows/pypi_daily_build.yml
@@ -1,0 +1,55 @@
+name: Pypi Daily Build
+
+# This workflow build and upload a pre-release package to test.pypi.org
+# The version is postfixed with .devYYYYMMDDHHMM, allowing to upload each minute.
+# This workflow is run each dày at 23:59 UTC, or on demand.
+# When run on schedule, a new package is generated only if latest commit is less than 1 day.
+#
+# Note : a scheduled workflow must be on the default branch to be executed.
+# 
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '59 23 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    env:
+      should_run: true
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: dev
+    - name: print latest_commit
+      run: echo ${{ github.sha }}
+    - name: check latest commit is less than a day
+      if: ${{ github.event_name == 'schedule' }}
+      run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_ENV ; true
+    - name: Set up Python
+      if: ${{ env.should_run != 'false' }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      if: ${{ env.should_run != 'false' }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U build twine wheel
+    - name: build dev version
+      if: ${{ env.should_run != 'false' }}
+      run: sed -i "s/\"$/.dev$(date +%Y%m%d%H%M)\"/" motioneye/__init__.py
+    - name: Build package
+      if: ${{ env.should_run != 'false' }}
+      run: python -m build
+    - name: Publish package
+      if: ${{ env.should_run != 'false' }}
+      run: twine  upload --repository testpypi -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*
+#      run: twine  upload --repository pypi -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
+      


### PR DESCRIPTION
This workflow push a daily build on <https://test.pypi.org/project/motioneye/>.
The version is postfixed with .devYYYYMMDDHHMM, so that the version is considered by pypi as a pre-release.

`sudo pip install -i https://test.pypi.org/simple/ motioneye` will install the last stable release.
`sudo pip install --pre -i https://test.pypi.org/simple/ motioneye` will install the last release, stable or pre-release.

You can see an exemple of pre-release on <https://test.pypi.org/project/motioneye/0.43.0.dev202205221220/>


