### PR TITLE
Fix 'No cameras configured' due to changed 'videodevice' string

### DIFF
--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -194,6 +194,7 @@ def is_local_motion_camera(config):
     """Tells if a camera is managed by the local motion instance."""
     return bool(
         config.get('videodevice')
+        or config.get('video_device')
         or config.get('netcam_url')
         or config.get('mmalcam_name')
     )


### PR DESCRIPTION
With motion >= 4.4 the config string 'videodevice' got changed to 'video_device' which is already correctly changed.

When restarting motioneye no cameras are found since it searches for the old string 'videodevice', which got replaced.

This adds 'video_device' while preserving 'videodevice' for motion < 4.4

Log without this PR:
`WARNING: camera config file at /etc/motioneye/camera-1.conf is incomplete, ignoring`