### PR TITLE
Fix flake8 which moved from GitLab to GitHub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: codespell
       # See args in setup.cfg
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
See: https://omeralkin.com/flake8-takedown-gitlab-repo/