### PR TITLE
Add scheduled workflow to default branch

### DIFF
--- a/.github/workflows/lint_legacy_python.yml
+++ b/.github/workflows/lint_legacy_python.yml
@@ -1,22 +1,24 @@
 name: lint_legacy_python
 on: [pull_request, push]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
    lint_legacy_python:
-     runs-on: ubuntu-latest
+     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
+     runs-on: ubuntu-20.04
      steps:
        - uses: actions/checkout@v3
-       - uses: actions/setup-python@v3
+       - uses: actions/setup-python@v4
          with:
            python-version: 2.7
        - run: |
            sudo apt-get -q update
-           sudo apt-get -qq upgrade
-           sudo apt-get -qq install curl ffmpeg libcurl4-openssl-dev libssl-dev motion ssh v4l-utils
+           sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends dist-upgrade
+           sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends install libcurl4-openssl-dev
        - run: pip install --upgrade pip wheel
-       - run: pip install codespell flake8 flake8-comprehensions pytest
+       - run: pip install codespell flake8 flake8-comprehensions
        - run: codespell --ignore-words-list="files',ot,process'" --skip="./.*,*.eot,*.gif,*.ico,*.png,*.ttf,*.woff"
-       - run: flake8 . --count --max-complexity=66 --max-line-length=125
-                       --select=E9,F63,F7,F82 --show-source --statistics
+       - run: flake8 . --count --max-complexity=66 --max-line-length=125 --select=E9,F63,F7,F82 --show-source --statistics
        - run: flake8 . --count --exit-zero --show-source --statistics
        - run: pip install -r requirements.txt
-       - run: pytest . || pytest --doctest-modules . || true

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,35 @@
+name: pre-commit-autoupdate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 15 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit-autoupdate:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: dev
+        # https://github.com/peter-evans/create-pull-request/issues/48
+        token: ${{ secrets.GH_PAT }}
+    - uses: actions/setup-python@v4
+      with:
+        # https://github.com/actions/python-versions/releases
+        python-version: '3.11'
+    - run: |
+        git checkout -b pre-commit-autoupdate
+        pip install pre-commit
+        pre-commit --version
+        pre-commit autoupdate
+        git diff --exit-code && exit 0
+        git add -A
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git commit -m '[CI/CD] pre-commit autoupdate'
+        gh pr create -B dev -H pre-commit-autoupdate --fill


### PR DESCRIPTION
required for it to run and also to allow manual "workflow_dispatch" triggers. Otherwise this has no effect on Python 2 branch.

Also updates the Python 2 lint workflow:
- Avoid concurrent and doubled execution.
- Update setup-python action.
- Do not install packages which are not required for Python 2 code lint or dedicated `requirements.txt` install test.
- Do not install and run `pytest` since the Python 2 branch does not contain any tests.