### PR TITLE
[CI/CD] Fix pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+
 jobs:
   pre-commit-autoupdate:
     runs-on: ubuntu-22.04
@@ -22,7 +25,9 @@ jobs:
       with:
         # https://github.com/actions/python-versions/releases
         python-version: '3.11'
-    - run: |
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
         git checkout -b pre-commit-autoupdate
         pip install pre-commit
         pre-commit --version
@@ -32,4 +37,5 @@ jobs:
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git commit -m '[CI/CD] pre-commit autoupdate'
-        gh pr create -B dev -H pre-commit-autoupdate --fill
+        git push -f origin pre-commit-autoupdate
+        gh pr create -B dev -H pre-commit-autoupdate -f -l 'CI/CD'


### PR DESCRIPTION
as GitHub CLI usage requires the GITHUB_TOKEN environment variable to be set.