### PR TITLE
Install latest available motion in init script

### DIFF
--- a/motioneye/extra/linux_init
+++ b/motioneye/extra/linux_init
@@ -19,34 +19,42 @@ done
 
 # Install dependencies
 if command -v apt-get > /dev/null; then
+  echo 'INFO: APT-based distribution detected, installing motionEye dependencies'
   (( SKIP_APT_UPDATE )) || apt-get update
-  # If distro can be detected and download available, install newer motion from GitHub
-  FILE=''
+  # If matching package can be found, install from motion project GitHub releases
   MOTION='motion'
   DISTRO=''
   [[ -f '/etc/os-release' ]] && DISTRO=$(sed -n '/^VERSION_CODENAME=/{s/^[^=]*=//p;q}' /etc/os-release)
   if [[ $DISTRO ]]; then
-    MOTION_REL='4.4.0'
-    MOTION_SUBREL='-1'
     ARCH=$(dpkg --print-architecture)
     # On ARMv6 Raspberry Pi models, download armv6hf package
     PI=''
-    [[ $(uname -m) == 'armv6l' && -f '/sys/firmware/devicetree/base/model' ]] && grep -q 'aspberry' /sys/firmware/devicetree/base/model && PI='pi_'
-    FILE="${PI}${DISTRO}_motion_${MOTION_REL}${MOTION_SUBREL}_${ARCH}.deb"
+    [[ ${ARCH} == 'armhf' && $(uname -m) == 'armv6l' ]] && PI='pi_'
+    echo "INFO: ${DISTRO^} on ${ARCH} detected, checking for latest motion package from GitHub releases"
     command -v curl > /dev/null || DEBIAN_FRONTEND="noninteractive" apt-get -y --no-install-recommends install curl
-    if curl -fLO "https://github.com/Motion-Project/motion/releases/download/release-${MOTION_REL}/${FILE}"
+    URL=$(curl -sSfL 'https://api.github.com/repos/Motion-Project/motion/releases' | awk -F\" "/browser_download_url.*${PI}${DISTRO}_motion_.*_${ARCH}.deb/{print \$4}" | head -1)
+    if [[ ${URL} ]]
     then
-      MOTION="./${FILE}"
+      echo "INFO: Matching package found, downloading: ${URL}"
+      if curl -fLo /tmp/motion.deb "${URL}"
+      then
+        MOTION='/tmp/motion.deb'
+      else
+        echo 'WARNING: Download failed, installing (older) motion package from APT repository instead'
+      fi
     else
-      echo "WARNING: No motion v${MOTION_REL} package found for your distro version, or download failed. The older motion version from your distro's package repository will be installed instead."
+      echo "WARNING: No motion package found for ${DISTRO^} on ${ARCH}, installing from APT repository instead"
     fi
+  else
+    echo 'WARNING: Distribution version could not be detected, installing motion from APT repository'
   fi
   DEBIAN_FRONTEND="noninteractive" apt-get -y --no-install-recommends install "${MOTION}" v4l-utils ffmpeg curl
-  [[ -f ${FILE} ]] && rm "${FILE}"
+  rm -f motion.deb
 elif command -v yum > /dev/null; then
+  echo 'INFO: YUM-based distribution detected, installing motionEye dependencies'
   yum -y install motion v4l-utils ffmpeg curl
 else
-  echo 'This system uses neither apt nor yum. Please install these dependencies manually:
+  echo 'WARNING: This system uses neither APT nor YUM. Please install these dependencies manually:
   motion v4l-utils ffmpeg curl'
 fi
 


### PR DESCRIPTION
Uses a more generic method to detect the latest available matching motion DEB package via GitHub API. Whenerver one is available, it is basically assured to be newer than the one from this distro version's package repository and hence should be preferred.

Most importantly this installs motion v4.5.0 on non-ancient Debian, Raspbian and Ubuntu versions. Since v4.5.0 does not contain settings changes, it is supported by motionEye.

Also this commit adds further informational messages to the init script, to show users what is going on.