### PR TITLE
[CI/CD] Add PyPI release workflow to dev branch

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,25 @@
+name: PyPI release
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        check-latest: true
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade build twine
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      #run: twine upload -r testpypi -u '__token__' -p '${{ secrets.TEST_PYPI_API_TOKEN }}' dist/*
+      run: twine upload -r pypi -u '__token__' -p '${{ secrets.PYPI_TOKEN }}' dist/*

--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.43.0"
+VERSION = "0.43.1b1"


### PR DESCRIPTION
and apply alpha "a1" version suffix while testing build and upload to testpypi.

When this works well, beta releases can be done with "bX" suffix to real PyPI, from a new beta branch.

#### ToDo
- [x] Switch from TestPyPI to PyPI
- [x] If everyone agrees, bump version to `0.43.1b1` for first beta release, to allow `pip install -U --pre motioneye` upgrades for those which installed v0.43.0 directly from this repo's `dev` branch already.