### PR TITLE
[CI/CD] Skip update_locales workflow on PRs from forks

### DIFF
--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   update_locales:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/setup-python@v4


### PR DESCRIPTION
When pull requests from forks are triggering the workflow, they have no access to secrets and no write access anyway. Updaing the locales can hence only fail and should then be skipped in the first place.