### PR TITLE
Fix camera-overlay div sometimes being clickable (but invisible) on creation

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -5110,9 +5110,6 @@ function recreateCameraFrames(cameras) {
             addCameraFrameUi(camera);
         }
 
-        /* overlay is always hidden after creating the frames */
-        hideCameraOverlay();
-
         var query = splitUrl().params;
         if ($('#cameraSelect').find('option').length < 2 && isAdmin() && !query.camera_ids) {
             /* invite the user to add a camera */

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -4721,7 +4721,7 @@ function addCameraFrameUi(cameraConfig) {
                     '<img class="camera">' +
                     '<div class="camera-progress"><img class="camera-progress"></div>' +
                 '</div>' +
-                '<div class="camera-overlay">' +
+                '<div class="camera-overlay" style="display: none;">' +
                     '<div class="camera-overlay-top">' +
                         '<div class="camera-name"><span class="camera-name"></span></div>' +
                         '<div class="camera-top-buttons">' +


### PR DESCRIPTION
Fixes #2702 .

There seemed occasionally to be race-condition between the creation of camera overlay in DOM and setting it hidden by `hideCameraOverlay` in `recreateCameraFrames` here:
https://github.com/motioneye-project/motioneye/blob/268c8a6ba2d9a5ebb29b421488321972f9777adf/motioneye/static/js/main.js#L5011

I left that call to `hideCameraOverlay` on line 5114 there for defensive purposes just in case, even though I think it currently is not needed. But if someone adds some more things to happen on show/hide of camera overlay, things would break without it. My change just eliminates the race-condition related to the overlay creation in DOM.