### PR TITLE
Always update systemd unit and runtime directory

### DIFF
--- a/motioneye/extra/linux_init
+++ b/motioneye/extra/linux_init
@@ -59,13 +59,19 @@ else
 fi
 
 # Pre-create config and data dirs and install configuration files
-[[ -d '/etc/motioneye' ]] || mkdir /etc/motioneye
-[[ -f '/etc/motioneye/motioneye.conf' ]] || cp extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
+if [[ -f '/etc/motioneye/motioneye.conf' ]]
+then
+  # Update PID file directory if the default from old motionEye is still present: https://github.com/motioneye-project/motioneye/issues/2657
+  grep -q '^run_path /var/run$' /etc/motioneye/motioneye.conf && sed -i '\|^run_path /var/run$|c\run_path /run/motioneye' /etc/motioneye/motioneye.conf
+else
+  [[ -d '/etc/motioneye' ]] || mkdir /etc/motioneye
+  cp extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
+fi
 chown -R motion:motion /etc/motioneye
 
 (( SKIP_SYSTEMD )) && exit 0
 
 # Install service
-[[ -f '/etc/systemd/system/motioneye.service' ]] || cp extra/motioneye.systemd /etc/systemd/system/motioneye.service
+cp extra/motioneye.systemd /etc/systemd/system/motioneye.service
 systemctl daemon-reload
 systemctl enable --now motioneye


### PR DESCRIPTION
Old motionEye installs may have an old incompatible systemd service in place. It makes sense to always update it. Customisations can and should be done via override configs in /etc/systemd/system/motioneye.conf.d.

Similarly, the old run_path is incompatible as now /run/motioneye is used as proper common standard. If the old untouched default is still in place, update it.

Fixes: https://github.com/motioneye-project/motioneye/issues/2657
_________
Translation updates are of course unrelated. However, our CI automatically fills empty translations with ones obtained from Google Translator. Generally this is fine, but Google has a rate limiting in place so that only a few are updated on each PR. We should probably remove this from the CI instead of harassing Google a bunch of times when new languages are added? 😄

I'd actually highly prefer DeepL over Google Translator, but using its API requires an account and has limits on free usage as well. I'll have a look into this when I find time.