### PR TITLE
[CI] docker: Update base image and fix armhf builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
 # By default, run as root
@@ -8,9 +8,13 @@ ARG RUN_GID=0
 COPY . /tmp/motioneye
 COPY docker/entrypoint.sh /entrypoint.sh
 
-RUN case "$(dpkg --print-architecture)" in \
-      'armhf') PACKAGES='python3-distutils'; printf '%b' '[global]\nextra-index-url=https://www.piwheels.org/simple/\n' > /etc/pip.conf;; \
-      *) PACKAGES='gcc libcurl4-openssl-dev libssl-dev python3-dev';; \
+# Build deps:
+# - armhf: Python headers, C compiler and libjpeg for Pillow, until piwheels provides the latest version: https://piwheels.org/project/pillow/
+# - other: Python headers, C compiler, libcurl and libssl for pycurl: https://pypi.org/project/pycurl/#files
+RUN printf '%b' '[global]\nbreak-system-packages=true\n' > /etc/pip.conf && \
+    case "$(dpkg --print-architecture)" in \
+      'armhf') PACKAGES='python3-dev gcc libjpeg62-turbo-dev'; printf '%b' 'extra-index-url=https://www.piwheels.org/simple/\n' >> /etc/pip.conf;; \
+      *) PACKAGES='python3-dev gcc libcurl4-openssl-dev libssl-dev';; \
     esac && \
     apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -qq --option Dpkg::Options::="--force-confnew" --no-install-recommends install \


### PR DESCRIPTION
Use Bookworm as Docker base image, now that is has been released this summer.

Since Bookworm, `libpython3.11-stdlib` ships with `/usr/lib/python3.11/EXTERNALLY-MANAGED`, which blocks module installs via `pip` on system and user level, basically restricting `pip` to be used in `venv` (and alike) only. There is a `pip.conf` flag to override this, and we want to ship our containers with the latest module versions, instead of up to 2.5 years old ones provided by the Debian APT repository.

Since piwheels does currently not provide latest Pillow wheels until all Bookworm (Python 3.11) wheels have been built, additional headers are required for armhf builds: https://piwheels.org/project/pillow/