### PR TITLE
CI | Workaround failing GRUB upgrade

### DIFF
--- a/.github/workflows/python_safety.yml
+++ b/.github/workflows/python_safety.yml
@@ -7,6 +7,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: 'ubuntu-20.04'
     steps:
+      - run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
       - run: sudo apt-get -q update
       - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends dist-upgrade
       - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends install

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-      - run: test '${{ matrix.dist }}' != 'ubuntu-22.04' || sudo apt-mark hold grub-efi-amd64-signed # Workaround for failing package upgrade on Jammy
+      - run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
       - run: sudo apt-get -q update
       - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends dist-upgrade
       - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends install

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-20.04
     steps:
+      - run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
       - run: sudo apt-get -q update
       - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends dist-upgrade
       - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install
@@ -31,7 +32,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-22.04
     steps:
-      - run: sudo apt-mark hold grub-efi-amd64-signed # Workaround for failing package upgrade on Jammy
+      - run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
       - run: sudo apt-get -q update
       - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends dist-upgrade
       - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install


### PR DESCRIPTION
Previously we saw this GRUB upgrade fail on Jammy only, but now it does as well on Focal, at least sometimes. Seems to be not consistently.

Whether it makes sense to upgrade all system APT packages or not is another question.