### PR TITLE
CI | Skip locales update on dependabot PRs

### DIFF
--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -8,8 +8,8 @@ concurrency:
 
 jobs:
   update_locales:
-    # Skip for forks which have no access to secrets (PAT)
-    if: github.event.pull_request.head.repo.fork == false
+    # Skip for forks and dependabot which have no access to secrets (PAT)
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     defaults:
       run:


### PR DESCRIPTION
as it intentionally has no access to secrets: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/