### PR TITLE
Revert "store surveillance user password as SHA1"

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -789,12 +789,7 @@ def main_ui_to_dict(ui):
         call_hook(ui['admin_username'], ui['admin_password'])
 
     if ui.get('normal_password') is not None:
-        if ui['normal_password']:
-            data['@normal_password'] = hashlib.sha1(
-                ui['normal_password'].encode('utf-8')
-            ).hexdigest()
-        else:
-            data['@normal_password'] = ''
+        data['@normal_password'] = ui['normal_password']
 
         call_hook(ui['normal_username'], ui['normal_password'])
 


### PR DESCRIPTION
Motion requires having plaintext password for stream_authentication in camera-*.conf files, and keeping the password hashed internally in ME isn't then possible.

If someone has a better idea that allows storing passwords hashed, I'm ready to scrap this PR, but it doesn't seem possible due to lack of support from Motion.

This fixes #2813 . See the discussion there for more context.