### PR TITLE
enhance motion startup logging and update "safety" workflow

### DIFF
--- a/.github/workflows/python_safety.yml
+++ b/.github/workflows/python_safety.yml
@@ -24,5 +24,7 @@ jobs:
           check-latest: true
       - run: pip install --upgrade pip setuptools
       - run: pip install safety .
-      - run: rm -Rfv /opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/pip-23.2.1.dist-info  # Workaround: https://github.com/motioneye-project/motioneye/pull/2883
-      - run: safety check
+      # Ignore CVE-2018-20225, which is IMO reasonably disputed: https://data.safetycli.com/v/67599/97c/
+      # "extra"-index-url means an index to "additionally" look for newer versions, pre-compiled wheels, or similar, not to force this index being used.
+      # There is "index-url" to enforce a different index: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-i
+      - run: safety check --ignore 67599

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -240,7 +240,7 @@ def find_ffmpeg() -> tuple:
         output = utils.call_subprocess([quote(binary), '-version'])
 
     except subprocess.CalledProcessError as e:
-        logging.error(f'ffmpeg: could find version: {e}')
+        logging.error(f'ffmpeg: could not find version: {e}')
         return None, None, None
 
     result = re.findall('ffmpeg version (.+?) ', output, re.IGNORECASE)
@@ -278,7 +278,7 @@ def find_ffmpeg() -> tuple:
 
         codecs[codec] = {'encoders': encoders, 'decoders': decoders}
 
-    logging.debug(f'using ffmpeg version {version}')
+    logging.debug(f'found ffmpeg executable "{binary}" version "{version}"')
 
     _ffmpeg_binary_cache = (binary, version, codecs)
 


### PR DESCRIPTION
I would actually like to append the `motion`/`ffmpeg` command's output to the error message, when obtaining the version fails. If these commands fail, either the binary is broken, or a [linked library](https://github.com/motioneye-project/motioneye/issues/2982), or the CLI has changed. In every case, it would be helpful to have that error in motionEye logs.

The exception does not include the command's STDERR. `utils.call_subprocess` redirects SDTERR to `/dev/null` by default. So we could pass `stderr=subprocess.PIPE` and append `output` to the error message. But better would be probably to store/access STDERR separately, to append only that one to the error message, while parsing only STDOUT for the actual version string.

While this can be merged, I'll run some more tests regarding this, and am open for suggestions, of course.