### PR TITLE
ci: switch to or add Ubuntu Noble runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   docker:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       packages: write

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pre-commit-autoupdate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   pre-commit:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/python_safety.yml
+++ b/.github/workflows/python_safety.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   python_safety:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
+    # ToDo: switch to ubuntu-24.04 once the implied openssl APT upgrade does not trigger a restart of all systemd services, killing the GitHub runner itself.
     runs-on: ubuntu-22.04
     steps:
       - run: sudo apt-get -q update

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   shellcheck:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install xz-utils
         run: |

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -18,6 +18,8 @@ jobs:
           # https://packages.ubuntu.com/search?suite=all&arch=any&searchon=names&keywords=python3
           - { dist: 'ubuntu-20.04', python: '3.8.2' }
           - { dist: 'ubuntu-22.04', python: '3.10.6' }
+          # ToDo: Enable ubuntu-24.04 test once the implied openssl APT upgrade does not trigger a restart of all systemd services, killing the GitHub runner itself.
+          #- { dist: 'ubuntu-24.04', python: '3.12.3' }
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"
     steps:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     strategy:
       matrix:
+        # ToDo: Enable ubuntu-24.04 test once the implied openssl APT upgrade does not trigger a restart of all systemd services, killing the GitHub runner itself.
         dist: ['ubuntu-20.04', 'ubuntu-22.04']
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"

--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -17,7 +17,7 @@ jobs:
   update_locales:
     # Skip for forks and dependabot which have no access to secrets (PAT)
     if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/setup-python@v5


### PR DESCRIPTION
Nasty, the `openssl` package upgrade, implied with the `libssl-dev` installation, triggers a restart of all systemd services, including the GitHub runner provider, which implicitly kills any workflow. Hence we need to wait for an update of this runner image. Monitoring releases here: https://github.com/actions/runner-images/tags