### PR TITLE
ci: ignore another newly failing Python safety CVE

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,8 +12,7 @@ permissions:
 jobs:
   docker:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
-    # ToDo: Switch to Ubuntu Noble once runner host end cancellations are fixed: https://github.com/actions/runner-images/issues/9848#issuecomment-2137140734
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       packages: write

--- a/.github/workflows/python_safety.yml
+++ b/.github/workflows/python_safety.yml
@@ -29,4 +29,5 @@ jobs:
       # Ignore CVE-2018-20225, which is IMO reasonably disputed: https://data.safetycli.com/v/67599/97c/
       # "extra"-index-url means an index to "additionally" look for newer versions, pre-compiled wheels, or similar, not to force this index being used.
       # There is "index-url" to enforce a different index: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-i
-      - run: safety check --ignore 67599
+      # Ignore CVE-2019-8341 as well: https://github.com/pyupio/safety/issues/527
+      - run: safety check --ignore 67599,70612


### PR DESCRIPTION
The very same applies as for CVE-2018-20225: disputed, ignored since years, and whichever database update triggered safety to suddenly fail on it, while there is no solution, and never will be one: https://github.com/pyupio/safety/issues/527

Not sure who to blame here, whether the NIST NVD database update triggered them to be recognised by `safety` now (with 30 days delay as free user), or whether  "the information ... curated by our (Safety's) Cybersecurity Intelligence Team" was not done well.

I hope it stops failing on more ancient disputed CVEs, otherwise I suggest to drop `safety` and move to another tool which better handles disputed CVEs.