### PR TITLE
Fix pylint warning `redefined-outer-name`

### DIFF
--- a/motioneye/controls/smbctl.py
+++ b/motioneye/controls/smbctl.py
@@ -305,11 +305,11 @@ def _check_mounts():
 
     logging.debug('checking SMB mounts...')
 
-    stop, start = update_mounts()
-    if stop:
+    stop_mounts, new_start = update_mounts()
+    if stop_mounts:
         motionctl.stop()
 
-    if start:
+    if new_start:
         motionctl.start()
 
     io_loop = IOLoop.current()

--- a/motioneye/server.py
+++ b/motioneye/server.py
@@ -228,14 +228,14 @@ handler_mapping = [
 
 
 def configure_signals():
-    def bye_handler(signal, frame):
+    def bye_handler(sig, frame):
         logging.info(_('interrompa signalo ricevita, fermanta …'))
 
         # shut down the IO loop if it has been started
         io_loop = IOLoop.current()
         io_loop.stop()
 
-    def child_handler(signal, frame):
+    def child_handler(sig, frame):
         # this is required for the multiprocessing mechanism to work
         multiprocessing.active_children()
 
@@ -416,7 +416,7 @@ def make_app(debug: bool = False) -> Application:
 def run():
     import motioneye
     from motioneye import cleanup, mjpgclient, motionctl, tasks, wsswitch
-    from motioneye.controls import smbctl
+    from motioneye.controls import smbctl as smbctl_module
 
     configure_signals()
     logging.info(_('saluton! ĉi tio estas motionEye-servilo ') + motioneye.VERSION)
@@ -425,7 +425,7 @@ def run():
     make_media_folders()
 
     if settings.SMB_SHARES:
-        stop, start = smbctl.update_mounts()  # @UnusedVariable
+        stop, start = smbctl_module.update_mounts()  # @UnusedVariable
         if start:
             start_motion()
 
@@ -446,7 +446,7 @@ def run():
         logging.info(_('mjpg klienta rubo-kolektanto komenciĝis'))
 
     if settings.SMB_SHARES:
-        smbctl.start()
+        smbctl_module.start()
         logging.info('smb mounts started')
 
     template.add_context('static_path', 'static/')
@@ -479,7 +479,7 @@ def run():
         motionctl.stop()
         logging.info(_('motion haltis'))
     if settings.SMB_SHARES:
-        smbctl.stop()
+        smbctl_module.stop()
         logging.info('smb mounts stopped')
 
     logging.info(_('adiaŭ!'))

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -1290,9 +1290,9 @@ def test_access(camera_id, service_name, data):
     return service.test_access()
 
 
-def update(camera_id, service_name, settings):
+def update(camera_id, service_name, new_settings):
     service = get(camera_id, service_name)
-    service.load(settings)
+    service.load(new_settings)
     service.save()
 
 


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `redefined-outer-name`.
"Used when a variable's name hides a name defined in an outer scope or except handler.. See [https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/redefined-outer-name.html](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/redefined-outer-name.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.