### PR TITLE
Make snapshot/streaming/embed (URLs) pop-ups work on all translations

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -3552,7 +3552,7 @@ function getCameraIds() {
 function runAlertDialog(message, onOk, options) {
     var params = {
         title: message,
-        buttons: i18n.gettext('bone'),
+        buttons: 'ok',
         onOk: onOk
     };
 


### PR DESCRIPTION
Fixes #2891 

Changed the function runAlertDialog to not depend on the selected language.

@MichaIng 
I hope this is how you envisioned the solution. If I need to change anything, please let me know!