### PR TITLE
Add Message-ID to emails.

### DIFF
--- a/motioneye/sendmail.py
+++ b/motioneye/sendmail.py
@@ -27,6 +27,7 @@ from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
+from email.utils import make_msgid
 
 from tornado.ioloop import IOLoop
 
@@ -53,6 +54,7 @@ def send_mail(server, port, account, password, tls, _from, to, subject, message,
     email['From'] = _from
     email['To'] = ', '.join(to)
     email['Date'] = formatdate(localtime=True)
+    email['Message-ID'] = make_msgid()
     email.attach(MIMEText(message))
 
     for name in reversed(files):


### PR DESCRIPTION
[RFC-2822](https://datatracker.ietf.org/doc/html/rfc2822.html#section-3.6.4) specifies that every email SHOULD have a Message-ID field. Some mail servers reject emails that do not have a Message-ID.
The eMails sent out by motioneye do not have a Message-ID.
This PR adds a Message-ID to the emails sent out by motioneye.