### PR TITLE
Fix rounding issue when reading config parameter value

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -915,7 +915,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         'threshold_maximum': ui['max_frame_change_threshold'],
         'threshold_tune': ui['auto_threshold_tuning'],
         'noise_tune': ui['auto_noise_detect'],
-        'noise_level': max(1, int(round(int(ui['noise_level']) * 2.55))),
+        'noise_level': max(1, round(int(ui['noise_level']) * 2.55)),
         'lightswitch_percent': ui['light_switch_detect'],
         'event_gap': int(ui['event_gap']),
         'pre_capture': int(ui['pre_capture']),

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1384,7 +1384,7 @@ def motion_camera_dict_to_ui(data):
         'auto_noise_detect': data['noise_tune'],
         'max_frame_change_threshold': data['threshold_maximum'],
         'auto_threshold_tuning': data['threshold_tune'],
-        'noise_level': int(int(data['noise_level']) / 2.55),
+        'noise_level': round(int(data['noise_level']) / 2.55),
         'light_switch_detect': data['lightswitch_percent'],
         'despeckle_filter': data['despeckle_filter'],
         'event_gap': int(data['event_gap']),


### PR DESCRIPTION
Fixing the config file parameter value conversion formula to match the one used in the opposite direction. It seemed to work now ok at least with UI setting values from 0% to 4% so the original 11+ yo version doesn't look like a deliberate tweak due to some oddity (unless the ways of Python doing rounding have changed from those times).