### PR TITLE
ci: remove Ubuntu 20.04 and add ARM builds/tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
-          path: /tmp/.buildx-cache
+          path: |
+            ${{ runner.temp }}/.buildx-cache
+            ${{ runner.temp }}/.buildx-cache-riscv64
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -70,10 +72,23 @@ jobs:
           #build-args: |
           #  KEY1=Value1
           #  KEY2=Value2
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new
+
+      - name: Build RISC-V
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile-riscv64
+          platforms: linux/riscv64
+          push: ${{ github.event_name == 'push' && github.repository == 'motioneye-project/motioneye' && steps.meta.outputs.tags != null }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-riscv64
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-riscv64-new
 
       - name: Move cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf ${{ runner.temp }}/.buildx-cache ${{ runner.temp }}/.buildx-cache-riscv64
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-riscv64-new ${{ runner.temp }}/.buildx-cache-riscv64

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -16,9 +16,10 @@ jobs:
       matrix:
         include:
           # https://packages.ubuntu.com/search?suite=all&arch=any&searchon=names&keywords=python3
-          - { dist: 'ubuntu-20.04', python: '3.8.2' }
           - { dist: 'ubuntu-22.04', python: '3.10.6' }
           - { dist: 'ubuntu-24.04', python: '3.12.3' }
+          - { dist: 'ubuntu-22.04-arm', python: '3.10.6' }
+          - { dist: 'ubuntu-24.04-arm', python: '3.12.3' }
       fail-fast: false
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"
@@ -27,9 +28,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
+      - if: matrix.dist == 'ubuntu-22.04' || matrix.dist == 'ubuntu-24.04'
+        run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
       - name: Ubuntu Noble workarounds
-        if: matrix.dist == 'ubuntu-24.04'
+        if: matrix.dist == 'ubuntu-24.04' || matrix.dist == 'ubuntu-24.04-arm'
         run: |
           # https://github.com/actions/runner-images/pull/9956
           sudo apt-get autopurge needrestart

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -13,14 +13,15 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     strategy:
       matrix:
-        dist: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-24.04']
+        dist: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
       fail-fast: false
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"
     steps:
-      - run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
+      - if: matrix.dist == 'ubuntu-22.04' || matrix.dist == 'ubuntu-24.04'
+        run: sudo apt-mark hold grub-efi-amd64-signed # GRUB does not always find the drive it was configured for
       - name: Ubuntu Noble workarounds
-        if: matrix.dist == 'ubuntu-24.04'
+        if: matrix.dist == 'ubuntu-24.04' || matrix.dist == 'ubuntu-24.04-arm'
         run: |
           # https://github.com/actions/runner-images/pull/9956
           # ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.

--- a/docker/Dockerfile-riscv64
+++ b/docker/Dockerfile-riscv64
@@ -1,0 +1,42 @@
+FROM debian:trixie-slim
+LABEL maintainer="Marcus Klein <himself@kleini.org>"
+
+# By default, run as root
+ARG RUN_UID=0
+ARG RUN_GID=0
+
+COPY . /tmp/motioneye
+COPY docker/entrypoint.sh /entrypoint.sh
+
+# Build deps: Python headers, C compiler, libcurl and libssl for pycurl: https://pypi.org/project/pycurl/#files, libjpeg for Pillow: https://pypi.org/project/pillow/#files
+RUN printf '%b' '[global]\nbreak-system-packages=true\n' > /etc/pip.conf && \
+    apt-get -q update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -qq --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+      ca-certificates curl python3 fdisk python3-dev gcc libcurl4-openssl-dev libssl-dev libjpeg62-turbo-dev && \
+    curl -sSfO 'https://bootstrap.pypa.io/get-pip.py' && \
+    python3 get-pip.py && \
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    python3 -m pip install --no-cache-dir /tmp/motioneye && \
+    motioneye_init --skip-systemd --skip-apt-update && \
+    # Change uid/gid of user/group motion to match our desired IDs. This will
+    # make it easier to use execute motion as our desired user later.
+    sed -i "s/^\(motion:[^:]*\):[0-9]*:[0-9]*:\(.*\)/\1:${RUN_UID}:${RUN_GID}:\2/" /etc/passwd && \
+    sed -i "s/^\(motion:[^:]*\):[0-9]*:\(.*\)/\1:${RUN_GID}:\2/" /etc/group && \
+    mv /etc/motioneye/motioneye.conf /etc/motioneye.conf.sample && \
+    mkdir /var/log/motioneye /var/lib/motioneye && \
+    chown motion:motion /var/log/motioneye /var/lib/motioneye && \
+    # Cleanup
+    python3 -m pip uninstall -y pip setuptools wheel && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -qq autopurge python3-dev gcc libcurl4-openssl-dev libssl-dev libjpeg62-turbo-dev && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists /var/cache/apt /tmp/motioneye get-pip.py /root/.cache
+
+# R/W needed for motionEye to update configurations
+VOLUME /etc/motioneye
+
+# Video & images
+VOLUME /var/lib/motioneye
+
+EXPOSE 8765
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Ubuntu 20.04 runners are not available anymore. Ubuntu ARM (aarch64/arm64) runners are available as public beta.

Also add RISC-V Docker image builds.