### PR TITLE
ci: update dependencies

### DIFF
--- a/.github/workflows/python_safety.yml
+++ b/.github/workflows/python_safety.yml
@@ -14,11 +14,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-24.04
     steps:
-      - run: sudo apt-get -q update
-      - run: sudo apt-get autopurge needrestart # https://github.com/actions/runner-images/pull/9956
       - run: echo -e '[global]\nbreak-system-packages=true' | sudo tee /etc/pip.conf # error: externally-managed-environment
-      - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq --no-install-recommends install
-             gcc libcurl4-openssl-dev libssl-dev
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -32,7 +32,7 @@ jobs:
       - run: sudo apt-get -q update
       - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends dist-upgrade
       - run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install
-                  ca-certificates curl gcc libcurl4-openssl-dev libssl-dev python3-dev
+                  ca-certificates curl python3-dev
       - run: curl -sSfO 'https://bootstrap.pypa.io/get-pip.py'
       - run: sudo python3 get-pip.py
       - run: sudo python3 -m pip install --upgrade pip setuptools wheel

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ These install instructions are constantly tested via CI/CD pipeline on Debian Bu
 
     _Here the commands for APT-based Linux distributions are given._
 
-    On **32-bit ARMv6 and ARMv7** systems, thanks to [piwheels](https://piwheels.org/), no development headers are required:
+    Thanks to pre-compiled wheels from PyPI, installing motionEye usually does not require anything but Python 3 and cURL with the ability to do HTTPS network requests:
     ```sh
     sudo apt update
-    sudo apt --no-install-recommends install ca-certificates curl python3 python3-distutils
+    sudo apt --no-install-recommends install ca-certificates curl python3
     ```
 
-    On **all other architectures** additional development headers are required:
+    On **ARMv6 and ARMv7 (32-bit), RISC-V and other rare CPU architectures** additional build dependencies may be required to compile the [Pillow](https://pypi.org/project/pillow/) and [PycURL](https://pypi.org/project/pycurl/) modules:
     ```sh
     sudo apt update
-    sudo apt --no-install-recommends install ca-certificates curl python3 python3-dev libcurl4-openssl-dev gcc libssl-dev
+    sudo apt --no-install-recommends install ca-certificates curl python3 python3-dev gcc libjpeg62-turbo-dev libcurl4-openssl-dev libssl-dev
     ```
 
 2. Install the Python package manager `pip`
@@ -43,12 +43,6 @@ These install instructions are constantly tested via CI/CD pipeline on Debian Bu
     ```sh
     grep -q '\[global\]' /etc/pip.conf 2> /dev/null || printf '%b' '[global]\n' | sudo tee -a /etc/pip.conf > /dev/null
     sudo sed -i '/^\[global\]/a\break-system-packages=true' /etc/pip.conf
-    ```
-
-    On **32-bit ARMv6 and ARMv7** systems, additionally configure `pip` to use pre-compiled wheels from [piwheels](https://piwheels.org/):
-    ```sh
-    grep -q '\[global\]' /etc/pip.conf 2> /dev/null || printf '%b' '[global]\n' | sudo tee -a /etc/pip.conf > /dev/null
-    sudo sed -i '/^\[global\]/a\extra-index-url=https://www.piwheels.org/simple/' /etc/pip.conf
     ```
 
 3. Install and setup **motionEye**

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,10 @@ COPY docker/entrypoint.sh /entrypoint.sh
 
 # Build deps:
 # - armhf: Python headers, C compiler and libjpeg for Pillow, until piwheels provides the latest version: https://piwheels.org/project/pillow/
-# - other: Python headers, C compiler, libcurl and libssl for pycurl: https://pypi.org/project/pycurl/#files
 RUN printf '%b' '[global]\nbreak-system-packages=true\n' > /etc/pip.conf && \
     case "$(dpkg --print-architecture)" in \
       'armhf') PACKAGES='python3-dev gcc libjpeg62-turbo-dev'; printf '%b' 'extra-index-url=https://www.piwheels.org/simple/\n' >> /etc/pip.conf;; \
-      *) PACKAGES='python3-dev gcc libcurl4-openssl-dev libssl-dev';; \
+      *) PACKAGES='';; \
     esac && \
     apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -qq --option Dpkg::Options::="--force-confnew" --no-install-recommends install \


### PR DESCRIPTION
PyPI does now provide PycURL wheels for common architectures. Common architectures hence do not require any build dependencies anymore. 32-bit ARM and RISC-V however do need to compile Pillow and PycURL. Remove the piwheels info from readme, as it does not always provide latest versions, like currently for Pillow, does not work with latest Debian versions right away. Keep it simpler and provide instructions for rare architectures inkl. ARMv6/7 in a single block.