### PR TITLE
Fix unsafe command execution in V4L2 control

### DIFF
--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -21,6 +21,7 @@ import re
 import stat
 import subprocess
 import time
+from shlex import quote
 
 from motioneye import utils
 
@@ -89,7 +90,7 @@ def list_resolutions(device):
     resolutions = set()
     output = b''
     started = time.time()
-    cmd = f"v4l2-ctl -d '{device}' --list-formats-ext | grep -vi stepwise | grep -oE '[0-9]+x[0-9]+' || true"
+    cmd = f"v4l2-ctl -d {quote(device)} --list-formats-ext | grep -vi stepwise | grep -oE '[0-9]+x[0-9]+' || true"
     logging.debug(f'running command "{cmd}"')
 
     try:


### PR DESCRIPTION
When using the `camera_add`/`add` motionEye web API, the camera device path for obtaining supported resolutions is passed via post request body. Adding single quotes to this input lifts the single-quotation in the final command string, allowing command substitution and hence remote command injection/execution. In this case, the final command is executed in shell context to allow piping and parsing the output with grep.

Use `shlex.quote()` to safely single-quote the input, and have embedded single-quotes escaped, to prevent any possible shell expansion, including variables and command substitutions.

Thanks to @hyperlyz for reporting this security vulnerability: #3142