### PR TITLE
Fix saving email notification settings with an empty From address

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1366,6 +1366,16 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
             ),
         )
 
+        if ui['email_notifications_from'] != '':
+            email_from = input_sanity_check(
+                emailValidRegExp,
+                ui['email_notifications_from'],
+                'email_notifications_from',
+                emailFailMessage,
+            )
+        else:
+            email_from = ''
+
         line = (
             "%(script)s '%(server)s' '%(port)s' '%(account)s' '%(password)s' '%(tls)s' '%(from)s' '%(to)s' "
             "'motion_start' '%%t' '%%Y-%%m-%%dT%%H:%%M:%%S' '%(timespan)s'"
@@ -1378,12 +1388,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
                 .replace(';', '\\;')
                 .replace('%', '%%'),
                 'tls': ui['email_notifications_smtp_tls'],
-                'from': input_sanity_check(
-                    emailValidRegExp,
-                    ui['email_notifications_from'],
-                    'email_notifications_from',
-                    emailFailMessage,
-                ),
+                'from': email_from,
                 'to': emails,
                 'timespan': ui['email_notifications_picture_time_span'],
             }


### PR DESCRIPTION
The backend `input_sanity_check()` throws a error: 
```
raise ValueError(
ERROR: Value "" for setting "email_notifications_from" did not match regex "^[A-Za-z0-9 _+.@^~<>,-]+$": Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space
```
 when the From address field in the email notification settings is empty, preventing the settings from being saved. The sanity-check regex requires at least one character. The frontend does not require this field to be set. The UI help mark says: https://github.com/motioneye-project/motioneye/blob/da7e73b67bd88ddb43117204a36c598d82ad2af3/motioneye/locale/en/LC_MESSAGES/motioneye.po#L1358 We now skip the sanity check when `email_notifications_from` is  empty. I guess we could also edit the regex itself if preferred, but it is shared across multiple input fields.