### PR TITLE
enh(auth): make session lifetime configurable for the normal (surveillance) user

### DIFF
--- a/motioneye/extra/motioneye.conf.sample
+++ b/motioneye/extra/motioneye.conf.sample
@@ -95,5 +95,5 @@ add_remove_cameras true
 # overrides the hostname (useful if motionEye runs behind a reverse proxy)
 #server_name motionEye
 
-# lifetime in hours of the session cookie for the normal (surveillance) user, minimum 1 hour (longer values increase risk if the cookie is stolen)
+# lifetime in hours of the session cookie for the normal (surveillance) user, minimum 1 hour (higher values increase risk if the cookie is stolen)
 normal_session_expiry_hours 720

--- a/motioneye/extra/motioneye.conf.sample
+++ b/motioneye/extra/motioneye.conf.sample
@@ -94,3 +94,6 @@ add_remove_cameras true
 
 # overrides the hostname (useful if motionEye runs behind a reverse proxy)
 #server_name motionEye
+
+# lifetime in hours of the session cookie for the normal (surveillance) user, minimum 1 hour
+normal_session_expiry_hours 720

--- a/motioneye/extra/motioneye.conf.sample
+++ b/motioneye/extra/motioneye.conf.sample
@@ -95,5 +95,5 @@ add_remove_cameras true
 # overrides the hostname (useful if motionEye runs behind a reverse proxy)
 #server_name motionEye
 
-# lifetime in hours of the session cookie for the normal (surveillance) user, minimum 1 hour
+# lifetime in hours of the session cookie for the normal (surveillance) user, minimum 1 hour (longer values increase risk if the cookie is stolen)
 normal_session_expiry_hours 720

--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -22,7 +22,7 @@ from time import time
 
 from tornado.web import HTTPError, RequestHandler
 
-from motioneye import VERSION, config, template
+from motioneye import VERSION, config, settings, template
 from motioneye.utils.authstate import verify_hmac_signature
 
 __all__ = ('BaseHandler', 'NotFoundHandler', 'ManifestHandler')
@@ -35,12 +35,18 @@ _SESSION_EXPIRY_SECONDS: int = 86400
 _session_store: dict = {}
 
 
+def session_expiry_seconds(user_type):
+    if user_type == 'normal':
+        return max(1, settings.NORMAL_SESSION_EXPIRY_HOURS) * 3600
+    return _SESSION_EXPIRY_SECONDS
+
+
 def create_session(user_type):
     """Create a secure session id with expiry."""
     session_id = token_hex(32)
     _session_store[session_id] = {
         'user': user_type,
-        'expires': time() + _SESSION_EXPIRY_SECONDS,
+        'expires': time() + session_expiry_seconds(user_type),
     }
     return session_id
 

--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -147,7 +147,7 @@ class BaseHandler(RequestHandler):
 
     def get_current_user(self):
         # Check for session-based authentication (via secure cookie)
-        session_id = self.get_secure_cookie('user')
+        session_id = self.get_signed_cookie('user')
         if session_id:
             try:
                 session_id = (

--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -38,7 +38,7 @@ _session_store: dict = {}
 
 def session_expiry_seconds(user_type: str) -> int:
     if user_type == 'normal':
-        return max(1, settings.NORMAL_SESSION_EXPIRY_HOURS) * 3600
+        return max(1, NORMAL_SESSION_EXPIRY_HOURS) * 3600
     return _SESSION_EXPIRY_SECONDS
 
 

--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -22,7 +22,8 @@ from time import time
 
 from tornado.web import HTTPError, RequestHandler
 
-from motioneye import VERSION, config, settings, template
+from motioneye import VERSION, config, template
+from motioneye.settings import NORMAL_SESSION_EXPIRY_HOURS
 from motioneye.utils.authstate import verify_hmac_signature
 
 __all__ = ('BaseHandler', 'NotFoundHandler', 'ManifestHandler')

--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -36,7 +36,7 @@ _SESSION_EXPIRY_SECONDS: int = 86400
 _session_store: dict = {}
 
 
-def session_expiry_seconds(user_type):
+def session_expiry_seconds(user_type: str) -> int:
     if user_type == 'normal':
         return max(1, settings.NORMAL_SESSION_EXPIRY_HOURS) * 3600
     return _SESSION_EXPIRY_SECONDS

--- a/motioneye/handlers/login.py
+++ b/motioneye/handlers/login.py
@@ -24,7 +24,7 @@ from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHash, VerificationError, VerifyMismatchError
 
 from motioneye import config
-from motioneye.handlers.base import BaseHandler, create_session
+from motioneye.handlers.base import BaseHandler, create_session, session_expiry_seconds
 from motioneye.utils.authstate import (
     PasswordHashState,
     build_password_hash_state,
@@ -143,7 +143,7 @@ class LoginHandler(BaseHandler):
         self.set_secure_cookie(
             'user',
             session_id,
-            expires_days=1,
+            expires_days=session_expiry_seconds(user_type) / 86400,
             httponly=True,
             secure=should_use_secure_cookie(self),
             samesite='Strict',

--- a/motioneye/handlers/login.py
+++ b/motioneye/handlers/login.py
@@ -140,7 +140,7 @@ class LoginHandler(BaseHandler):
             return self.finish_json({'error': 'invalid credentials'})
 
         session_id = create_session(user_type)
-        self.set_secure_cookie(
+        self.set_signed_cookie(
             'user',
             session_id,
             expires_days=session_expiry_seconds(user_type) / 86400,

--- a/motioneye/handlers/logout.py
+++ b/motioneye/handlers/logout.py
@@ -26,7 +26,7 @@ class LogoutHandler(BaseHandler):
         self.clear_cookie('user')
 
         # Invalidate the session id stored in the secure cookie
-        session_id = self.get_secure_cookie('user')
+        session_id = self.get_signed_cookie('user')
         if session_id:
             session_id = (
                 session_id.decode('utf-8')

--- a/motioneye/settings.py
+++ b/motioneye/settings.py
@@ -140,3 +140,6 @@ PASSWORD_HOOK = None
 
 # provides the possibility to override the hostname
 SERVER_NAME = socket.gethostname()
+
+# lifetime in hours of the session cookie for the normal (surveillance) user, minimum 1 hour
+NORMAL_SESSION_EXPIRY_HOURS = 720

--- a/tests/test_handlers/test_login.py
+++ b/tests/test_handlers/test_login.py
@@ -1,11 +1,14 @@
 import json
+from email.utils import parsedate_to_datetime
 from hashlib import sha1
+from http.cookies import SimpleCookie
 from unittest.mock import patch
 
 import tornado.testing
 from argon2 import PasswordHasher
 
-from motioneye import config
+from motioneye import config, settings
+from motioneye.handlers.base import _session_store
 from motioneye.handlers.login import LoginHandler
 from tests.test_handlers import HandlerTestCase
 
@@ -121,6 +124,86 @@ class LoginHandlerTest(HandlerTestCase):
                 )
                 self.assertEqual(200, response.code)
                 mock_set_normal.assert_called_once_with(normal_plain)
+
+    def _assert_session_lifetime(
+        self, response, user_type: str, expected_seconds: int
+    ) -> None:
+        response_date = parsedate_to_datetime(response.headers['Date'])
+        cookie = SimpleCookie()
+        cookie.load(response.headers.get('Set-Cookie', ''))
+        cookie_expires = parsedate_to_datetime(cookie['user']['expires'])
+
+        self.assertAlmostEqual(
+            expected_seconds,
+            (cookie_expires - response_date).total_seconds(),
+            delta=1,
+        )
+
+        self.assertEqual(1, len(_session_store))
+        session = next(iter(_session_store.values()))
+        self.assertEqual(user_type, session['user'])
+        self.assertAlmostEqual(cookie_expires.timestamp(), session['expires'], delta=1)
+
+    def test_normal_session_lifetime_configurable(self):
+        normal_user = 'user'
+        normal_pass = 'watcher'
+        main_config = {
+            '@admin_username': 'admin',
+            '@admin_password': ph.hash('adminpass'),
+            '@normal_username': normal_user,
+            '@normal_password': ph.hash(normal_pass),
+        }
+        with patch.object(settings, 'NORMAL_SESSION_EXPIRY_HOURS', 5):
+            with patch.object(config, '_main_config_cache', main_config):
+                response = self.fetch(
+                    '/login',
+                    method='POST',
+                    body=f'username={normal_user}&password={normal_pass}',
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                )
+        self.assertEqual(200, response.code)
+        self._assert_session_lifetime(response, 'normal', 5 * 3600)
+
+    def test_admin_session_lifetime_not_configurable(self):
+        admin_user = 'admin'
+        admin_pass = 's3cret'
+        main_config = {
+            '@admin_username': admin_user,
+            '@admin_password': ph.hash(admin_pass),
+            '@normal_username': '',
+            '@normal_password': '',
+        }
+        # even a large normal-user lifetime must not affect the admin cookie
+        with patch.object(settings, 'NORMAL_SESSION_EXPIRY_HOURS', 999):
+            with patch.object(config, '_main_config_cache', main_config):
+                response = self.fetch(
+                    '/login',
+                    method='POST',
+                    body=f'username={admin_user}&password={admin_pass}',
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                )
+        self.assertEqual(200, response.code)
+        self._assert_session_lifetime(response, 'admin', 24 * 3600)
+
+    def test_normal_session_lifetime_minimum_clamp(self):
+        normal_user = 'user'
+        normal_pass = 'watcher'
+        main_config = {
+            '@admin_username': 'admin',
+            '@admin_password': ph.hash('adminpass'),
+            '@normal_username': normal_user,
+            '@normal_password': ph.hash(normal_pass),
+        }
+        with patch.object(settings, 'NORMAL_SESSION_EXPIRY_HOURS', 0):
+            with patch.object(config, '_main_config_cache', main_config):
+                response = self.fetch(
+                    '/login',
+                    method='POST',
+                    body=f'username={normal_user}&password={normal_pass}',
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                )
+        self.assertEqual(200, response.code)
+        self._assert_session_lifetime(response, 'normal', 1 * 3600)
 
     def test_logout(self):
         cookie = self.make_session_cookie('admin')

--- a/tests/test_handlers/test_login.py
+++ b/tests/test_handlers/test_login.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 import tornado.testing
 from argon2 import PasswordHasher
 
-from motioneye import config, settings
+from motioneye import config
+from motioneye.handlers import base
 from motioneye.handlers.base import _session_store
 from motioneye.handlers.login import LoginHandler
 from tests.test_handlers import HandlerTestCase
@@ -153,7 +154,7 @@ class LoginHandlerTest(HandlerTestCase):
             '@normal_username': normal_user,
             '@normal_password': ph.hash(normal_pass),
         }
-        with patch.object(settings, 'NORMAL_SESSION_EXPIRY_HOURS', 5):
+        with patch.object(base, 'NORMAL_SESSION_EXPIRY_HOURS', 5):
             with patch.object(config, '_main_config_cache', main_config):
                 response = self.fetch(
                     '/login',
@@ -174,7 +175,7 @@ class LoginHandlerTest(HandlerTestCase):
             '@normal_password': '',
         }
         # even a large normal-user lifetime must not affect the admin cookie
-        with patch.object(settings, 'NORMAL_SESSION_EXPIRY_HOURS', 999):
+        with patch.object(base, 'NORMAL_SESSION_EXPIRY_HOURS', 999):
             with patch.object(config, '_main_config_cache', main_config):
                 response = self.fetch(
                     '/login',
@@ -194,7 +195,7 @@ class LoginHandlerTest(HandlerTestCase):
             '@normal_username': normal_user,
             '@normal_password': ph.hash(normal_pass),
         }
-        with patch.object(settings, 'NORMAL_SESSION_EXPIRY_HOURS', 0):
+        with patch.object(base, 'NORMAL_SESSION_EXPIRY_HOURS', 0):
             with patch.object(config, '_main_config_cache', main_config):
                 response = self.fetch(
                     '/login',


### PR DESCRIPTION
Adds `normal_session_expiry_hours` to motioneye.conf so the session lifetime for the normal (surveillance) user can be configured, with a default of 30 days (720h) and a minimum of 1 hour. As discussed in #3364.


