### PR TITLE
perf(mediafiles): let list_media filter by time window

### DIFF
--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -109,6 +109,9 @@ def _list_media_files(
     exts: List[str],
     sub_path: Optional[str] = None,
     with_stat: bool = True,
+    *,
+    min_timestamp: Optional[float] = None,
+    max_timestamp: Optional[float] = None,
 ) -> List[tuple]:
     # Determine scan path based on sub_path parameter
     if sub_path is not None:
@@ -120,6 +123,9 @@ def _list_media_files(
             return []
     else:
         scan_path = base_path
+
+    # loop-invariant: only compute the window flag once
+    windowed: bool = min_timestamp is not None or max_timestamp is not None
 
     media_files = []
     for entry in os.scandir(scan_path):
@@ -135,7 +141,7 @@ def _list_media_files(
 
             # If stat is not needed, use None as placeholder
             st = None
-            if with_stat:
+            if with_stat or windowed:
                 # stat call may fail due to race conditions or permission issues
                 try:
                     st = entry.stat(follow_symlinks=False)
@@ -143,11 +149,29 @@ def _list_media_files(
                     logging.error(f'stat failed: {e}')
                     continue
 
-            media_files.append((entry.path, st))
+                # Skip files outside the caller's window before any of the
+                # expensive per-file work in _do_list_media. Bounds are
+                # inclusive, i.e. wider than any caller's own filter.
+                if windowed:
+                    mtime: float = st.st_mtime
+                    if min_timestamp is not None and mtime < min_timestamp:
+                        continue
+                    if max_timestamp is not None and mtime > max_timestamp:
+                        continue
+
+            media_files.append((entry.path, st if with_stat else None))
 
         # recurse into subdirectories only when no sub_path filter is set
         elif sub_path is None and entry.is_dir(follow_symlinks=False):
-            media_files.extend(_list_media_files(entry.path, exts, with_stat=with_stat))
+            media_files.extend(
+                _list_media_files(
+                    entry.path,
+                    exts,
+                    with_stat=with_stat,
+                    min_timestamp=min_timestamp,
+                    max_timestamp=max_timestamp,
+                )
+            )
 
     return media_files
 
@@ -206,10 +230,25 @@ def _remove_older_files(
         uploadservices.clean_cloud(directory, {}, clean_cloud_info)
 
 
-def _do_list_media(pipe, target_dir, exts, sub_path, with_stat):
+def _do_list_media(
+    pipe,
+    target_dir: str,
+    exts: List[str],
+    sub_path: Optional[str] = None,
+    with_stat: bool = True,
+    min_timestamp: Optional[float] = None,
+    max_timestamp: Optional[float] = None,
+) -> None:
     from mimetypes import guess_type
 
-    mf = _list_media_files(target_dir, exts, sub_path, with_stat)
+    mf = _list_media_files(
+        target_dir,
+        exts,
+        sub_path,
+        with_stat,
+        min_timestamp=min_timestamp,
+        max_timestamp=max_timestamp,
+    )
     for p, st in mf:
         path = p[len(target_dir) :]
         if not path.startswith('/'):
@@ -534,6 +573,9 @@ def list_media(
     media_type: str,
     prefix: Optional[str] = None,
     with_stat: bool = True,
+    *,
+    min_timestamp: Optional[float] = None,
+    max_timestamp: Optional[float] = None,
 ) -> Awaitable:
     target_dir = camera_config.get('target_dir')
     utils.validate_paths(prefix, target_dir=target_dir)
@@ -548,7 +590,16 @@ def list_media(
 
     parent_pipe, child_pipe = multiprocessing.Pipe(duplex=False)
     process = multiprocessing.Process(
-        target=_do_list_media, args=(child_pipe, target_dir, exts, prefix, with_stat)
+        target=_do_list_media,
+        args=(
+            child_pipe,
+            target_dir,
+            exts,
+            prefix,
+            with_stat,
+            min_timestamp,
+            max_timestamp,
+        ),
     )
     process.start()
     child_pipe.close()

--- a/motioneye/sendmail.py
+++ b/motioneye/sendmail.py
@@ -170,8 +170,18 @@ def make_message(
         prefix = moment.strftime('%Y-%m-%d')
         logging.debug('narrowing down still images path lookup to %s' % prefix)
 
+    # only pictures within +/- timespan are ever used (see on_media_files),
+    # so let the listing skip the rest instead of formatting and piping a
+    # whole day of snapshots
+    event_timestamp: float = time.mktime(moment.timetuple())
     fut = utils.cast_future(
-        mediafiles.list_media(camera_config, media_type='picture', prefix=prefix)
+        mediafiles.list_media(
+            camera_config,
+            media_type='picture',
+            prefix=prefix,
+            min_timestamp=event_timestamp - timespan,
+            max_timestamp=event_timestamp + timespan,
+        )
     )
     fut.add_done_callback(on_media_files)
 


### PR DESCRIPTION
Follow-up to #3412 (second defect). Independent of #3413 — this branch is based directly on `dev` and touches different lines, so the two can be reviewed and merged in either order.

## Problem

`list_media()` formats and pipes every file in the camera's directory before the caller filters it. Both notification senders then discard everything outside `abs(m['timestamp'] - event) < timespan`, which is typically all but one or two of them.

Per file that is thrown away, the child process currently builds a dict, calls `guess_type()`, formats two `pretty_date_time()` strings and a `pretty_size()`, pickles the result and writes it to a pipe that the parent drains on a 0.5 s `IOLoop` timer.

## Change

`list_media()` and the two functions below it accept optional `min_timestamp` / `max_timestamp`. When given, `_list_media_files()` compares `st.st_mtime` right after the `stat()` it already performs and `continue`s on a miss, so none of the above work happens for files the caller would discard anyway.

`sendmail.py` passes the event time ± the picture timespan. `sendtelegram.py` will do the same once #3413 lands — it needs the `int(timespan)` coercion from that PR first, since `timespan` is currently still a string there and the arithmetic would raise.

## Why the caller-side filter stays

The bounds are **inclusive**, so the pre-filter is deliberately *wider* than each sender's own strict-`<` test, and the senders keep their existing filter unchanged. The listing may return a file or two that the sender then drops, and the delivered set is identical by construction.

I preferred that over moving the boundary decision into the listing: replicating inclusive-versus-strict semantics there would make `_list_media_files()` responsible for a correctness property that currently lives in the caller, and any drift would silently change which pictures get attached. As a pure performance change it seemed better for the fast path to be a superset.

## Compatibility

The new parameters are keyword-only with `None` defaults. With no window passed, `windowed` is `False`, `with_stat or windowed` reduces to `with_stat`, and the appended tuple is unchanged — the no-window path is identity by inspection. The recursive call for subdirectories forwards both bounds, so filtering applies at any depth.

## Measurements

Raspberry Pi 4, real camera directory, timed end to end through `list_media()` so the figures include the process spawn, formatting, pipe and drain:

| | files in tree | listing | files returned |
| --- | --- | --- | --- |
| before | 57,093 | 63.3 s | 56,765 |
| after | 57,093 | 1.5 s | 68 |

Cold cache the windowed listing is 2.5 s, so it fits inside the default 10 s `list_media_timeout` where the unwindowed one overruns it by more than 6x.

The cost scales with directory size and hardware. On a Pi Zero 2 W with ~77k files the windowed listing is 10.6 s warm — much better than before, but that box needs a shorter retention rather than only this change.

## Verification

- `black`, `isort`, `ruff format`, `ruff check` and `flake8` with the arguments from `.pre-commit-config.yaml`; the only change in `ruff check` output against `dev` is two fewer `I001` findings and four new `FA100` for the new `Optional[float]` parameters, matching the `Optional[str]` parameters beside them.
- Full test suite on Python 3.13 on an ARM board: 136 pass, including the 38 in `tests/test_mediafiles.py` that exercise `_list_media_files()` directly.
- Differential check against unpatched `dev` on a live 52,807-file directory: with no window the two return **identical** `(path, mtime, size)` sets; with a window the result is a strict subset that contains every in-window file; with `with_stat=False` both return all-`None` stat entries and identical sets.
- Running on the reporter's cameras since, with the notification timeouts returned to the default 10 from the 120 previously needed.

## Relationship to #3413

Independent. This branch is cut from `dev` and shares no commits with #3413; the two touch different lines of `sendmail.py` and merge in either order.

`sendtelegram.py` is deliberately left alone here. Its `timespan` is still a string on `dev`, so the arithmetic for the window would raise — it picks this up in a two-line follow-up once #3413 lands and coerces it.
