### PR TITLE
fix: keep the 'fork' multiprocessing start method on Python 3.14

### DIFF
--- a/motioneye/meyectl.py
+++ b/motioneye/meyectl.py
@@ -20,6 +20,7 @@ import argparse
 import gettext
 import locale
 import logging
+import multiprocessing
 import os.path
 import sys
 from shlex import quote
@@ -314,6 +315,29 @@ def print_version_and_exit():
     sys.exit()
 
 
+def configure_multiprocessing():
+    """Keep the 'fork' start method for our multiprocessing children.
+
+    Python 3.14 changed the default start method on POSIX platforms
+    other than macOS from 'fork' to 'forkserver' (python/cpython#84559).
+    A 'forkserver' child does not inherit the parent's runtime state,
+    but ours rely on it: the settings loaded from the config file and
+    the logging configuration. Without 'fork' the cleanup child looks
+    for cameras in the built-in default conf path, finds none and
+    deletes nothing (#3411); the zip child writes its archive under the
+    built-in default media path and the task pool reads the upload
+    state from the built-in default conf path.
+    """
+    if 'fork' not in multiprocessing.get_all_start_methods():
+        return
+
+    # force=True: don't fail if something already resolved the default
+    # context (any get_context() call or multiprocessing object pins it).
+    # Objects created before this call keep that context, so it must run
+    # before any multiprocessing object exists.
+    multiprocessing.set_start_method('fork', force=True)
+
+
 def main():
     for a in sys.argv:
         if a == '-v':
@@ -322,6 +346,7 @@ def main():
     if len(sys.argv) < 2 or sys.argv[1] == '-h':
         print_usage_and_exit(0)
 
+    configure_multiprocessing()
     load_settings()
 
     command = sys.argv[1]

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import multiprocessing
+import os
+import subprocess
+import sys
+import unittest
+from tempfile import TemporaryDirectory
+
+import motioneye
+
+# Regression test for #3411. Our multiprocessing children (cleanup, media
+# listing, zip, task pool) rely on inheriting the parent's runtime state:
+# the settings loaded from the config file and the logging configuration.
+# Python 3.14 made 'forkserver' the default start method on POSIX, whose
+# children start from a fresh interpreter and only see import-time
+# defaults. meyectl.configure_multiprocessing() must keep 'fork'.
+#
+# The check runs in its own interpreter so the process-wide start method
+# cannot leak into the rest of the test run. The child function lives in
+# that script so both 'fork' and 'forkserver' can resolve it; the
+# __main__ guard keeps the forkserver from re-running the parent part
+# when it imports the script as __mp_main__.
+_SCRIPT = '''
+import logging
+import multiprocessing
+import sys
+
+from motioneye import meyectl, settings
+
+
+def report(path):
+    with open(path, 'w') as f:
+        print(settings.CONF_PATH, file=f)
+        print(logging.getLogger().level, file=f)
+
+
+if __name__ == '__main__':
+    conf_path, report_path = sys.argv[1:3]
+
+    meyectl.configure_multiprocessing()
+
+    # what load_settings() and configure_logging() do in the parent
+    settings.CONF_PATH = conf_path
+    logging.basicConfig(level=logging.DEBUG)
+
+    p = multiprocessing.Process(target=report, args=(report_path,), daemon=True)
+    p.start()
+    p.join(30)
+    if p.is_alive():
+        p.kill()
+        sys.exit('the child did not finish in 30 seconds')
+
+    sys.exit(p.exitcode)
+'''
+
+
+@unittest.skipUnless(
+    'fork' in multiprocessing.get_all_start_methods(),
+    "the 'fork' start method is not available on this platform",
+)
+class TestMultiprocessing(unittest.TestCase):
+    def test_children_inherit_settings_and_logging(self):
+        with TemporaryDirectory() as tmp_dir:
+            script = os.path.join(tmp_dir, 'spawn_child.py')
+            with open(script, 'w') as f:
+                f.write(_SCRIPT)
+
+            conf_path = os.path.join(tmp_dir, 'conf')
+            report_path = os.path.join(tmp_dir, 'report.txt')
+
+            # make the child import the same motioneye package as this test
+            env = dict(os.environ)
+            package_root = os.path.dirname(os.path.dirname(motioneye.__file__))
+            env['PYTHONPATH'] = os.pathsep.join(
+                p for p in (package_root, env.get('PYTHONPATH')) if p
+            )
+
+            result = subprocess.run(
+                [sys.executable, script, conf_path, report_path],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(
+                os.path.exists(report_path), 'the child never reported back'
+            )
+
+            with open(report_path) as f:
+                child_conf_path, child_log_level = f.read().splitlines()
+
+        self.assertEqual(
+            child_conf_path,
+            conf_path,
+            f"child saw CONF_PATH {child_conf_path!r}; it must inherit the parent's",
+        )
+        self.assertEqual(
+            int(child_log_level),
+            logging.DEBUG,
+            "child root logger level must inherit the parent's DEBUG",
+        )


### PR DESCRIPTION
Fixes #3411. Related: hassio-addons/app-motioneye#625 (same mechanism; the add-on only needs to pick up the motionEye release that contains this).

## Problem

Python 3.14 changed the default `multiprocessing` start method on POSIX platforms other than macOS from `fork` to `forkserver` (python/cpython#84559). A `forkserver` child starts from a fresh interpreter and does not inherit the parent's runtime state. Our children rely on that state: the settings `load_settings()` applies from the config file and the logging `configure_logging()` sets up.

The periodic cleanup child (`cleanup._run_process` -> `_do_cleanup`, no arguments) lists cameras in the built-in default `CONF_PATH`, finds no `camera-N.conf`, and silently deletes nothing. Its debug lines never appear because its root logger has only the bare `basicConfig()` handler at WARNING. That is #3411. The zip child (`_do_zip`) writes under the built-in default `MEDIA_PATH`, which is hassio-addons/app-motioneye#625. The task pool workers load the upload-service state from the built-in default `CONF_PATH`. Every child loses its log lines.

It surfaced now because the HA add-on moved from Python 3.12.12 to 3.14.7 in the same release that moved motionEye to 0.44.0, so reporters attributed it to 0.44.0. `cleanup.py` has not changed since 2022 and is identical in 0.43.1b5 and 0.44.0. #3254 fixed the `forkserver` pickling crash but did not set a start method, so startup succeeds and the children run with import-time defaults.

Any host on Python 3.14 is affected: cleanup breaks wherever `conf_path` differs from the built-in default (the HA add-on uses `/data/motioneye`), the zip download wherever `media_path` does, and the children's log lines are lost everywhere. A stock install with the default paths keeps deleting, silently. The upstream Docker image (debian:trixie-slim, Python 3.13) is not affected.

## Change

`meyectl.configure_multiprocessing()` sets the start method to `fork` once, first thing in `main()`, before any multiprocessing object exists. Every spawn site (`cleanup._run_process`, `mediafiles.list_media` / `get_zipped_content` / `make_timelapse_movie`, `tasks.start`) is reachable only through `main()`, and the setting survives `Daemon.daemonize()`'s `os.fork()` calls, so `-b` mode is covered. `force=True` keeps it from raising if something resolved the default context earlier.

The guard uses `get_all_start_methods()`, so it is a no-op on Windows. On macOS, which is unsupported, it also selects `fork`; happy to change the guard to `sys.platform != 'darwin'` if preferred.

## Why `fork` is safe here

This restores exactly the behaviour every Linux install on Python 3.13 and earlier has. The parent does hold the task `Pool`'s handler threads when the children fork, so `os.fork()` issues the Python 3.12+ `DeprecationWarning` about forking a multi-threaded process. CPython clears it after warning, so it cannot become an error under `-W error`, and the default filters hide it. It is identical to what 3.12 and 3.13 users already run. The children never touch the IOLoop or the pool's queues.

## Test

`tests/test_multiprocessing.py` runs a small script in its own interpreter, so the process-wide start method cannot leak into the rest of the run. The script calls `configure_multiprocessing()`, sets `settings.CONF_PATH` and configures logging the way `load_settings()` and `configure_logging()` do, spawns a child under the default context and checks it sees both. It only discriminates on Python 3.14 and later, which the two 3.14.3 CI jobs cover. With the `configure_multiprocessing()` call removed it fails on 3.14.7 with:

```
AssertionError: '<sys.prefix>/etc/motioneye' != '/tmp/.../conf' : child saw CONF_PATH '<sys.prefix>/etc/motioneye'; it must inherit the parent's
```

## Verification

- Reproduced on Python 3.14.7 (the add-on's version) with the 0.44.0 tree, no Docker: settings loaded from a config file in a non-default directory, a three-day-old movie planted, `cleanup._do_cleanup` spawned with `multiprocessing.Process` as `cleanup._run_process` does. Default context: child sees the built-in default `CONF_PATH`, `cameras=[]`, exit 0, movie still there, no debug lines. With this patch applied, or with `set_start_method('fork')` on the plain 0.44.0 tree, or on Python 3.13.5: child sees the real conf dir, `cameras=[1]`, movie deleted, all debug lines present.
- Full test suite on Python 3.14.7 and 3.13.5 against `dev` with this patch: 137 pass on both.
- `ruff check`, `ruff format`, `black`, `isort`, `flake8`, `bandit`, `pyupgrade`, `codespell` with the arguments and versions from `.pre-commit-config.yaml`, and `mypy --ignore-missing-imports`: clean.

## Follow-up

The direction #3254 took, making the children start-method-agnostic, would remove the dependency on `fork`: pass `CONF_PATH`, `MEDIA_PATH` and the log level into the target functions, or re-run `load_settings()` and `configure_logging()` in an initializer, and replace the task `Pool` with a thread as the TODO in `tasks.py` already suggests. Until then `fork` is required.
